### PR TITLE
Updates to YAML handling

### DIFF
--- a/roboglia/base/device.py
+++ b/roboglia/base/device.py
@@ -65,9 +65,9 @@ class BaseDevice():
         with open(model_file, 'r') as f:
             model_ini = yaml.load(f, Loader=yaml.FullLoader)
         self.__registers = {}
-        for index, reg_info in enumerate(model_ini['registers']):
-            check_key('name', reg_info, self.__model + ' register',
-                      index, logger)
+        for reg_name, reg_info in model_ini['registers'].items():
+            # add name to the dictionary
+            reg_info['name'] = reg_name
             reg_class_name = reg_info.get('class', self.default_register())
             reg_class = get_registered_class(reg_class_name)
             reg_info['device'] = self

--- a/roboglia/base/devices/DUMMY.yml
+++ b/roboglia/base/devices/DUMMY.yml
@@ -2,17 +2,17 @@
 # should only use registers from base package
 #
 registers:
-  - name: model
+  model:
     address: 0
     size: 2
     default: 42
 
-  - name: revision
+  revision:
     address: 10
     max: 254
     default: 16
 
-  - name: delay
+  delay:
     class: RegisterWithConversion
     address: 20
     access: RW
@@ -20,7 +20,7 @@ registers:
     max: 254
     factor: 0.5
 
-  - name: desired_pos
+  desired_pos:
     class: RegisterWithConversion
     address: 30
     size: 2
@@ -29,7 +29,7 @@ registers:
     factor: 3.41
     offset: 512
 
-  - name: desired_speed
+  desired_speed:
     class: RegisterWithConversion
     address: 40
     size: 2
@@ -37,7 +37,7 @@ registers:
     max: 1023
     factor: 8.973684210526316
 
-  - name: desired_load
+  desired_load:
     class: RegisterWithConversion
     address: 50
     size: 2
@@ -45,12 +45,12 @@ registers:
     max: 1023
     factor: 10.24
 
-  - name: enable_device
+  enable_device:
     class: BoolRegister
     address: 60
     access: RW
 
-  - name: current_pos
+  current_pos:
     class: RegisterWithConversion
     address: 70
     size: 2
@@ -60,7 +60,7 @@ registers:
     offset: 512
     default: 512
 
-  - name: current_speed
+  current_speed:
     class: RegisterWithThreshold
     address: 80
     size: 2
@@ -70,7 +70,7 @@ registers:
     threshold: 1024
     default: 512
 
-  - name: current_load
+  current_load:
     class: RegisterWithThreshold
     address: 90
     size: 2
@@ -82,7 +82,7 @@ registers:
 
     # not really often in practice as RW
     # here for testing
-  - name: writtable_current_load
+  writtable_current_load:
     class: RegisterWithThreshold
     address: 95
     size: 2

--- a/roboglia/base/robot.py
+++ b/roboglia/base/robot.py
@@ -67,8 +67,9 @@ class BaseRobot():
         self.__devices = {}
         logger.info(f'Initializing devices...')
         check_key('devices', init_dict, 'robot', '', logger)
-        for index, dev_info in enumerate(init_dict['devices']):
-            check_key('name', dev_info, 'device', index, logger)
+        for dev_name, dev_info in init_dict['devices'].items():
+            # add the name in the dev_info
+            dev_info['name'] = dev_name
             check_key('bus', dev_info, 'device', dev_info['name'], logger)
             check_key(dev_info['bus'], self.buses,
                       'device', dev_info['name'],
@@ -79,8 +80,8 @@ class BaseRobot():
             dev_info['bus'] = dev_bus
             dev_class = get_registered_class(dev_info['class'])
             new_dev = dev_class(dev_info)
-            self.__devices[dev_info['name']] = new_dev
-            logger.debug(f'\tdevice {dev_info["name"]} added')
+            self.__devices[dev_name] = new_dev
+            logger.debug(f'\tdevice {dev_name} added')
 
     def __init_joints(self, init_dict):
         """Called by ``__init__`` to parse and instantiate joints."""

--- a/roboglia/base/robot.py
+++ b/roboglia/base/robot.py
@@ -149,7 +149,7 @@ class BaseRobot():
             logger.debug(f'\tsync {sync_name} added')
 
     @property
-    def name (self):
+    def name(self):
         """(read-only) The name of the robot."""
         return self.__name
 

--- a/roboglia/base/robot.py
+++ b/roboglia/base/robot.py
@@ -28,11 +28,15 @@ class BaseRobot():
     """
     def __init__(self, init_dict):
         logger.info('***** Initializing robot *************')
-        self.__init_buses(init_dict)
-        self.__init_devices(init_dict)
-        self.__init_joints(init_dict)
-        self.__init_groups(init_dict)
-        self.__init_syncs(init_dict)
+        if len(init_dict) > 1:
+            logger.warning(f'Only the first robot will be considered.')
+        self.__name = list(init_dict)[0]
+        components = init_dict[self.__name]
+        self.__init_buses(components)
+        self.__init_devices(components)
+        self.__init_joints(components)
+        self.__init_groups(components)
+        self.__init_syncs(components)
         logger.info('***** Initialization complete ********')
 
     @classmethod
@@ -143,28 +147,33 @@ class BaseRobot():
             logger.debug(f'\tsync {sync_info["name"]} added')
 
     @property
+    def name (self):
+        """(read-only) The name of the robot."""
+        return self.__name
+
+    @property
     def buses(self):
-        """(read-only) the buses of the robot as a dict."""
+        """(read-only) The buses of the robot as a dict."""
         return self.__buses
 
     @property
     def devices(self):
-        """(read-only) the devices of the robot as a dict."""
+        """(read-only) The devices of the robot as a dict."""
         return self.__devices
 
     @property
     def joints(self):
-        """(read-only) the joints of the robot as a dict."""
+        """(read-only) The joints of the robot as a dict."""
         return self.__joints
 
     @property
     def groups(self):
-        """(read-only) the groups of the robot as a dict."""
+        """(read-only) The groups of the robot as a dict."""
         return self.__groups
 
     @property
     def syncs(self):
-        """(read-ony) the syncs of the robot as a dict."""
+        """(read-only) The syncs of the robot as a dict."""
         return self.__syncs
 
     def start(self):

--- a/roboglia/base/robot.py
+++ b/roboglia/base/robot.py
@@ -51,15 +51,16 @@ class BaseRobot():
         self.__buses = {}
         logger.info(f'Initializing buses...')
         check_key('buses', init_dict, 'robot', '', logger)
-        for index, bus_info in enumerate(init_dict['buses']):
-            check_key('name', bus_info, 'bus', index, logger)
+        for bus_name, bus_info in init_dict['buses'].items():
+            # add the name in the dict
+            bus_info['name'] = bus_name
             # add the robot as the parent of the bus
             bus_info['robot'] = self
             check_key('class', bus_info, 'bus', bus_info['name'], logger)
             bus_class = get_registered_class(bus_info['class'])
             new_bus = bus_class(bus_info)
-            self.__buses[bus_info['name']] = new_bus
-            logger.debug(f'\tbus {bus_info["name"]} added')
+            self.__buses[bus_name] = new_bus
+            logger.debug(f'\tbus {bus_name} added')
 
     def __init_devices(self, init_dict):
         """Called by ``__init__`` to parse and instantiate devices."""

--- a/roboglia/base/robot.py
+++ b/roboglia/base/robot.py
@@ -50,7 +50,7 @@ class BaseRobot():
         """Called by ``__init__`` to parse and instantiate buses."""
         self.__buses = {}
         logger.info(f'Initializing buses...')
-        check_key('buses', init_dict, 'robot', '', logger)
+        check_key('buses', init_dict, 'robot', self.name, logger)
         for bus_name, bus_info in init_dict['buses'].items():
             # add the name in the dict
             bus_info['name'] = bus_name
@@ -87,8 +87,9 @@ class BaseRobot():
         """Called by ``__init__`` to parse and instantiate joints."""
         self.__joints = {}
         logger.info(f'Initializing joints...')
-        for index, joint_info in enumerate(init_dict.get('joints', [])):
-            check_key('name', joint_info, 'joint', index, logger)
+        for joint_name, joint_info in init_dict.get('joints', {}).items():
+            # add the name in the joint_info
+            joint_info['name'] = joint_name
             check_key('device', joint_info, 'joint',
                       joint_info['name'], logger)
             check_key(joint_info['device'], self.devices, 'joint',
@@ -101,8 +102,8 @@ class BaseRobot():
             joint_info['device'] = device
             joint_class = get_registered_class(joint_info['class'])
             new_joint = joint_class(joint_info)
-            self.__joints[joint_info['name']] = new_joint
-            logger.debug(f'\tjoint {joint_info["name"]} added')
+            self.__joints[joint_name] = new_joint
+            logger.debug(f'\tjoint {joint_name} added')
 
     def __init_groups(self, init_dict):
         """Called by ``__init__`` to parse and instantiate groups."""

--- a/roboglia/base/robot.py
+++ b/roboglia/base/robot.py
@@ -56,7 +56,7 @@ class BaseRobot():
             bus_info['name'] = bus_name
             # add the robot as the parent of the bus
             bus_info['robot'] = self
-            check_key('class', bus_info, 'bus', bus_info['name'], logger)
+            check_key('class', bus_info, 'bus', bus_name, logger)
             bus_class = get_registered_class(bus_info['class'])
             new_bus = bus_class(bus_info)
             self.__buses[bus_name] = new_bus
@@ -70,11 +70,11 @@ class BaseRobot():
         for dev_name, dev_info in init_dict['devices'].items():
             # add the name in the dev_info
             dev_info['name'] = dev_name
-            check_key('bus', dev_info, 'device', dev_info['name'], logger)
+            check_key('bus', dev_info, 'device', dev_name, logger)
             check_key(dev_info['bus'], self.buses,
-                      'device', dev_info['name'],
+                      'device', dev_name,
                       logger, f'bus {dev_info["bus"]} does not exist')
-            check_key('class', dev_info, 'device', dev_info['name'], logger)
+            check_key('class', dev_info, 'device', dev_name, logger)
             # convert the parent to object reference
             dev_bus = self.buses[dev_info['bus']]
             dev_info['bus'] = dev_bus
@@ -91,11 +91,11 @@ class BaseRobot():
             # add the name in the joint_info
             joint_info['name'] = joint_name
             check_key('device', joint_info, 'joint',
-                      joint_info['name'], logger)
+                      joint_name, logger)
             check_key(joint_info['device'], self.devices, 'joint',
-                      joint_info['name'], logger,
+                      joint_name, logger,
                       f'device {joint_info["device"]} does not exist')
-            check_key('class', joint_info, 'joint', joint_info['name'], logger)
+            check_key('class', joint_info, 'joint', joint_name, logger)
             # convert device reference from name to object
             dev_name = joint_info['device']
             device = self.devices[dev_name]
@@ -109,45 +109,44 @@ class BaseRobot():
         """Called by ``__init__`` to parse and instantiate groups."""
         self.__groups = {}
         logger.info(f'Initializing groups...')
-        for index, grp_info in enumerate(init_dict.get('groups', [])):
-            check_key('name', grp_info, 'group', index, logger)
+        for grp_name, grp_info in init_dict.get('groups', {}).items():
             new_grp = set()
             # groups of devices
             for dev_name in grp_info.get('devices', []):
-                check_key(dev_name, self.devices, 'group', grp_info['name'],
+                check_key(dev_name, self.devices, 'group', grp_name,
                           logger, f'device {dev_name} does not exist')
                 new_grp.add(self.devices[dev_name])
             # groups of joints
             for joint_name in grp_info.get('joints', []):
-                check_key(joint_name, self.joints, 'group', grp_info['name'],
+                check_key(joint_name, self.joints, 'group', grp_name,
                           logger, f'joint {joint_name} does not exist')
                 new_grp.add(self.joints[joint_name])
             # groups of groups
-            for grp_name in grp_info.get('groups', []):
-                check_key(grp_name, self.groups, 'group', grp_info['name'],
-                          logger, f'group {grp_name} does not exist')
-                new_grp.update(self.groups[grp_name])
-            self.__groups[grp_info['name']] = new_grp
-            logger.debug(f'\tgroup {grp_info["name"]} added')
+            for sgrp_name in grp_info.get('groups', []):
+                check_key(sgrp_name, self.groups, 'group', grp_name,
+                          logger, f'group {sgrp_name} does not exist')
+                new_grp.update(self.groups[sgrp_name])
+            self.__groups[grp_name] = new_grp
+            logger.debug(f'\tgroup {grp_name} added')
 
     def __init_syncs(self, init_dict):
         """Called by ``__init__`` to parse and instantiate syncs."""
         self.__syncs = {}
         logger.info(f'Initializing syncs...')
-        for index, sync_info in enumerate(init_dict.get('syncs', [])):
-            check_key('name', sync_info, 'sync', index, logger)
-            check_key('group', sync_info, 'sync', sync_info['name'], logger)
+        for sync_name, sync_info in init_dict.get('syncs', {}).items():
+            sync_info['name'] = sync_name
+            check_key('group', sync_info, 'sync', sync_name, logger)
             check_key(sync_info['group'], self.groups, 'sync',
-                      sync_info['name'], logger,
+                      sync_name, logger,
                       f'group {sync_info["group"]} does not exist')
-            check_key('class', sync_info, 'sync', sync_info['name'], logger)
+            check_key('class', sync_info, 'sync', sync_name, logger)
             # convert group references
             group_name = sync_info['group']
             sync_info['group'] = self.groups[group_name]
             sync_class = get_registered_class(sync_info['class'])
             new_sync = sync_class(sync_info)
-            self.__syncs[sync_info['name']] = new_sync
-            logger.debug(f'\tsync {sync_info["name"]} added')
+            self.__syncs[sync_name] = new_sync
+            logger.debug(f'\tsync {sync_name} added')
 
     @property
     def name (self):

--- a/roboglia/dynamixel/devices/AX-12A.yml
+++ b/roboglia/dynamixel/devices/AX-12A.yml
@@ -2,26 +2,30 @@
 # http://emanual.robotis.com/docs/en/dxl/ax/ax-12a/#control-table
 #
 registers:
-  - name: model_number
+  model_number:
     address: 0
     size: 2
     default: 12
 
-  - name: firmware
+  firmware:
     address: 2
     max: 254
 
-#  ID register will be skipped as we have the id in the device and
-#  we will not support updates of this register in roboglia
+  id:
+    address: 3
+    max: 252
+    default: 1
+# ID is technically RW but we don't support changing it from roboglia
+# use Dynamixel tools like DynamixelWizard
 
-  - name: baud_rate 
+  baud_rate:
     class: DynamixelAXBaudRateRegister
     address: 4
     access: RW
     default: 1
     max: 207
 
-  - name: return_delay_time
+  return_delay_time:
     class: RegisterWithConversion
     address: 5
     access: RW
@@ -29,13 +33,13 @@ registers:
     max: 254
     factor: 0.5
 
-  - name: cw_angle_limit
+  cw_angle_limit:
     address: 6
     size: 2
     max: 1023
     access: RW
 
-  - name: cw_angle_limit_deg
+  cw_angle_limit_deg:
     class: RegisterWithConversion
     address: 6
     size: 2
@@ -44,7 +48,7 @@ registers:
     factor: 3.41
     offset: 512
 
-  - name: cw_angle_limit_rad
+  cw_angle_limit_rad:
     class: RegisterWithConversion
     address: 6
     size: 2
@@ -53,7 +57,7 @@ registers:
     factor: 195.3786081396107
     offset: 512
 
-  - name: ccw_angle_limit
+  ccw_angle_limit:
     class: RegisterWithConversion
     address: 8
     size: 2
@@ -63,13 +67,13 @@ registers:
     offset: 512
     default: 1023
 
-  - name: temperature_limit
+  temperature_limit:
     address: 11
     access|: RW
     default: 70
     max: 99
 
-  - name: min_voltage_limit
+  min_voltage_limit:
     class: RegisterWithConversion
     address: 12
     access: RW
@@ -78,7 +82,7 @@ registers:
     factor: 10.0
     default: 60
 
-  - name: max_voltage_limit
+  max_voltage_limit:
     class: RegisterWithConversion
     address: 13
     access: RW
@@ -87,7 +91,7 @@ registers:
     factor: 10.0
     default: 140
 
-  - name: max_torque
+  max_torque:
     class: RegisterWithConversion
     address: 14
     size: 2
@@ -96,59 +100,59 @@ registers:
     factor: 10.23
     default: 1023
 
-  - name: status_return_level
+  status_return_level:
     address: 16
     access: RW
     max: 2
     default: 2
 
-  - name: alarm_led
+  alarm_led:
     address: 17
     access: RW
     default: 32
 
-  - name: shutdown
+  shutdown:
     address: 18
     access: RW
     default: 32
 
-  - name: torque_enable
+  torque_enable:
     class: BoolRegister
     address: 24
     access: RW
 
-  - name: led
+  led:
     class: BoolRegister
     address: 25
     access: RW
 
-  - name: cw_compliance_margin
+  cw_compliance_margin:
     class: RegisterWithConversion
     address: 26
     access: RW
     factor: 3.41
     default: 1  
 
-  - name: ccw_compliance_margin
+  ccw_compliance_margin:
     class: RegisterWithConversion
     address: 27
     access: RW
     factor: 3.41
     default: 1
 
-  - name: cw_compliance_slope
+  cw_compliance_slope:
     class: DynamixelAXComplianceSlopeRegister
     address: 28
     access: RW
     default: 32
 
-  - name: ccw_compliance_slope
+  ccw_compliance_slope:
     class: DynamixelAXComplianceSlopeRegister
     address: 29
     access: RW
     default: 32
 
-  - name: goal_position
+  goal_position:
     class: RegisterWithConversion
     address: 30
     size: 2
@@ -157,7 +161,7 @@ registers:
     factor: 3.41
     offset: 512
 
-  - name: moving_speed
+  moving_speed:
     class: RegisterWithConversion
     address: 32
     size: 2
@@ -165,7 +169,7 @@ registers:
     max: 1023
     factor: 8.973684210526316
 
-  - name: torque_limit
+  torque_limit:
     class: RegisterWithConversion
     address: 34
     size: 2
@@ -173,7 +177,7 @@ registers:
     max: 1023
     factor: 10.23
 
-  - name: present_position
+  present_position:
     class: RegisterWithConversion
     address: 36
     size: 2
@@ -182,7 +186,7 @@ registers:
     factor: 3.41
     offset: 512
 
-  - name: present_speed
+  present_speed:
     class: RegisterWithThreshold
     address: 38
     size: 2
@@ -191,7 +195,7 @@ registers:
     factor: 8.973684210526316
     threshold: 1024
 
-  - name: present_load
+  present_load:
     class: RegisterWithThreshold
     address: 40
     size: 2
@@ -200,32 +204,32 @@ registers:
     factor: 10.23
     threshold: 1024
 
-  - name: present_voltage
+  present_voltage:
     class: RegisterWithConversion
     address: 42
     access: R
     factor: 10.0
 
-  - name: present_temperature
+  present_temperature:
     address: 43
     access: R
 
-  - name: registered_instruction
+  registered_instruction:
     class: BoolRegister
     address: 44
     access: R
 
-  - name: moving
+  moving:
     class: BoolRegister
     address: 46
     access: R
 
-  - name: locking
+  locking:
     class: BoolRegister
     address: 47
     access: RW
 
-  - name: punch
+  punch:
     address: 48
     size: 2
     access: RW

--- a/roboglia/dynamixel/devices/XL-320.yml
+++ b/roboglia/dynamixel/devices/XL-320.yml
@@ -2,26 +2,30 @@
 # http://emanual.robotis.com/docs/en/dxl/x/xl320/#control-table
 #
 registers:
-  - name: model_number
+  model_number:
     address: 0
     size: 2
     default: 350
 
-  - name: firmware
+  firmware:
     address: 2
     max: 254
 
-#  ID register will be skipped as we have the id in the device and
-#  we will not support updates of this register in roboglia
+  id:
+    address: 3
+    max: 252
+    default: 1
+# ID is technically RW but we don't support changing it from roboglia
+# use Dynamixel tools like DynamixelWizard
 
-  - name: baud_rate 
+  baud_rate:
     class: DynamixelXLBaudRateRegister
     address: 4
     access: RW
     default: 3
     max: 207
 
-  - name: return_delay_time
+  return_delay_time:
     class: RegisterWithConversion
     address: 5
     access: RW
@@ -29,7 +33,7 @@ registers:
     max: 254
     factor: 0.5
 
-  - name: cw_angle_limit_deg
+  cw_angle_limit_deg:
     class: RegisterWithConversion
     address: 6
     size: 2
@@ -38,7 +42,7 @@ registers:
     factor: 3.41
     offset: 512
 
-  - name: cw_angle_limit_rad
+  cw_angle_limit_rad:
     class: RegisterWithConversion
     address: 6
     size: 2
@@ -47,7 +51,7 @@ registers:
     factor: 195.3786081396107
     offset: 512
 
-  - name: ccw_angle_limit_deg
+  ccw_angle_limit_deg:
     class: RegisterWithConversion
     address: 8
     size: 2
@@ -57,7 +61,7 @@ registers:
     offset: 512
     default: 1023
 
-  - name: ccw_angle_limit_rad
+  ccw_angle_limit_rad:
     class: RegisterWithConversion
     address: 8
     size: 2
@@ -66,20 +70,20 @@ registers:
     factor: 195.3786081396107
     offset: 512
 
-  - name: control_mode
+  control_mode:
     address: 11
     access: RW
     min: 1
     max: 2
     default: 2
 
-  - name: temperature_limit
+  temperature_limit:
     address: 12
     access: RW
     default: 65
     max: 150
 
-  - name: min_voltage_limit
+  min_voltage_limit:
     class: RegisterWithConversion
     address: 13
     access: RW
@@ -88,7 +92,7 @@ registers:
     factor: 10.0
     default: 60
 
-  - name: max_voltage_limit
+  max_voltage_limit:
     class: RegisterWithConversion
     address: 14
     access: RW
@@ -97,7 +101,7 @@ registers:
     factor: 10.0
     default: 90
 
-  - name: max_torque
+  -max_torque:
     class: RegisterWithConversion
     address: 15
     size: 2
@@ -106,43 +110,43 @@ registers:
     factor: 10.23
     default: 1023
 
-  - name: status_return_level
+  status_return_level:
     address: 17
     access: RW
     max: 2
     default: 2
 
-  - name: shutdown
+  shutdown:
     address: 18
     access: RW
     max: 7
     default: 3
 
-  - name: torque_enable
+  torque_enable:
     class: BoolRegister
     address: 24
     access: RW
 
-  - name: led
+  led:
     address: 25
     access: RW
     max: 7
 
-  - name: d_gain
+  d_gain:
     class: RegisterWithConversion
     address: 27
     access: RW
     max: 254
     factor: 250.0
 
-  - name: i_gain
+  i_gain:
     class: RegisterWithConversion
     address: 28
     access: RW
     max: 254
     factor: 2.048
 
-  - name: p_gain
+  p_gain:
     class: RegisterWithConversion
     address: 29
     access: RW
@@ -150,7 +154,7 @@ registers:
     default: 32
     factor: 8.0
 
-  - name: goal_position_deg
+  goal_position_deg:
     class: RegisterWithConversion
     address: 30
     size: 2
@@ -159,7 +163,7 @@ registers:
     factor: 3.41
     offset: 512
 
-  - name: goal_position_rad
+  goal_position_rad:
     class: RegisterWithConversion
     address: 30
     size: 2
@@ -169,7 +173,7 @@ registers:
     offset: 512
 
     # in rot per minute
-  - name: moving_speed_rpm
+  moving_speed_rpm:
     class: RegisterWithConversion
     address: 32
     size: 2
@@ -178,7 +182,7 @@ registers:
     factor: 8.973684210526316
 
     # in rad per second
-  - name: moving_speed_rps
+  moving_speed_rps:
     class: RegisterWithConversion
     address: 32
     size: 2
@@ -186,7 +190,7 @@ registers:
     max: 1023
     factor: 0.939722013047473  
 
-  - name: torque_limit
+  torque_limit:
     class: RegisterWithConversion
     address: 35
     size: 2
@@ -194,7 +198,7 @@ registers:
     max: 1023
     factor: 10.23
 
-  - name: present_position_deg
+  present_position_deg:
     class: RegisterWithConversion
     address: 37
     size: 2
@@ -203,7 +207,7 @@ registers:
     factor: 3.41
     offset: 512
 
-  - name: present_position_rad
+  present_position_rad:
     class: RegisterWithConversion
     address: 37
     size: 2
@@ -213,7 +217,7 @@ registers:
     offset: 512
 
     # in rot per min
-  - name: present_speed_rpm
+  present_speed_rpm:
     class: RegisterWithThreshold
     address: 39
     size: 2
@@ -223,7 +227,7 @@ registers:
     threshold: 1024
 
     # in rad per sec
-  - name: present_speed_rps
+  present_speed_rps:
     class: RegisterWithThreshold
     address: 39
     size: 2
@@ -232,7 +236,7 @@ registers:
     factor: 0.939722013047473
     threshold: 1024
 
-  - name: present_load
+  present_load:
     class: RegisterWithThreshold
     address: 41
     size: 2
@@ -241,31 +245,31 @@ registers:
     factor: 10.23
     threshold: 1024
 
-  - name: present_voltage
+  present_voltage:
     class: RegisterWithConversion
     address: 45
     access: R
     factor: 10.0
 
-  - name: present_temperature
+  present_temperature:
     address: 46
     access: R
 
-  - name: registered_instruction
+  registered_instruction:
     class: BoolRegister
     address: 47
     access: R
 
-  - name: moving
+  moving:
     class: BoolRegister
     address: 49
     access: R
 
-  - name: hardware_error
+  hardware_error:
     address: 50
     access: R
 
-  - name: punch
+  punch:
     address: 51
     size: 2
     access: RW

--- a/tests/dummy_robot.yml
+++ b/tests/dummy_robot.yml
@@ -2,11 +2,11 @@
 #
 dummy:
   buses:
-    - name: busA
+    busA:
       class: ShareableFileBus
       port: /tmp/busA.log
 
-    - name: busB
+    busB:
       class: ShareableFileBus
       port: /tmp/busB.log
       auto: False

--- a/tests/dummy_robot.yml
+++ b/tests/dummy_robot.yml
@@ -67,17 +67,17 @@ dummy:
       auto: False
 
   groups:
-    - name: devices
+    devices:
       devices: [d01, d02]
 
-    - name: joints
+    joints:
       joints: [pan, tilt]
 
-    - name: all
+    all:
       groups: [devices, joints]
 
   syncs:
-    - name: read
+    read:
       class: BaseReadSync
       frequency: 100.0
       group: devices
@@ -86,7 +86,7 @@ dummy:
       # to control the test and make sure that they are no side
       # effects on more simple checks
 
-    - name: write
+    write:
       class: BaseWriteSync
       frequency: 100.0
       group: devices

--- a/tests/dummy_robot.yml
+++ b/tests/dummy_robot.yml
@@ -1,98 +1,99 @@
 # robot defintion file for running automated tests
 #
-buses:
-  - name: busA
-    class: ShareableFileBus
-    port: /tmp/busA.log
+dummy:
+  buses:
+    - name: busA
+      class: ShareableFileBus
+      port: /tmp/busA.log
 
-  - name: busB
-    class: ShareableFileBus
-    port: /tmp/busB.log
-    auto: False
+    - name: busB
+      class: ShareableFileBus
+      port: /tmp/busB.log
+      auto: False
 
-devices:
-  - name: d01
-    class: BaseDevice
-    bus: busA
-    id: 1
-    model: DUMMY
+  devices:
+    - name: d01
+      class: BaseDevice
+      bus: busA
+      id: 1
+      model: DUMMY
 
-  - name: d02
-    class: BaseDevice
-    bus: busA
-    id: 2
-    model: DUMMY
-    auto: False
+    - name: d02
+      class: BaseDevice
+      bus: busA
+      id: 2
+      model: DUMMY
+      auto: False
 
-    # this is not in syncs
-  - name: d03
-    class: BaseDevice
-    bus: busA
-    id: 3
-    model: DUMMY
+      # this is not in syncs
+    - name: d03
+      class: BaseDevice
+      bus: busA
+      id: 3
+      model: DUMMY
 
-  - name: d04
-    class: BaseDevice
-    bus: busB
-    id: 4
-    model: DUMMY
+    - name: d04
+      class: BaseDevice
+      bus: busB
+      id: 4
+      model: DUMMY
 
-joints:
-  - name: pan
-    class: JointPVL
-    device: d01
-    pos_read: current_pos
-    pos_write: desired_pos
-    vel_read: current_speed
-    vel_write: desired_speed
-    load_read: current_load
-    load_write: desired_load
-    activate: enable_device
-    min: -30.0
-    max: 30.0
+  joints:
+    - name: pan
+      class: JointPVL
+      device: d01
+      pos_read: current_pos
+      pos_write: desired_pos
+      vel_read: current_speed
+      vel_write: desired_speed
+      load_read: current_load
+      load_write: desired_load
+      activate: enable_device
+      min: -30.0
+      max: 30.0
 
-  - name: tilt
-    class: JointPVL
-    device: d02
-    pos_read: current_pos
-    pos_write: desired_pos
-    vel_read: current_speed
-    vel_write: desired_speed
-    load_read: current_load
-    load_write: desired_load
-    inverse: True
-    activate: enable_device
-    offset: 45.0
-    auto: False
+    - name: tilt
+      class: JointPVL
+      device: d02
+      pos_read: current_pos
+      pos_write: desired_pos
+      vel_read: current_speed
+      vel_write: desired_speed
+      load_read: current_load
+      load_write: desired_load
+      inverse: True
+      activate: enable_device
+      offset: 45.0
+      auto: False
 
-groups:
-  - name: devices
-    devices: [d01, d02]
+  groups:
+    - name: devices
+      devices: [d01, d02]
 
-  - name: joints
-    joints: [pan, tilt]
+    - name: joints
+      joints: [pan, tilt]
 
-  - name: all
-    groups: [devices, joints]
+    - name: all
+      groups: [devices, joints]
 
-syncs:
-  - name: read
-    class: BaseReadSync
-    frequency: 100.0
-    group: devices
-    registers: ['current_pos', 'current_speed', 'current_load']
-    # we specifically want the loops not to start automatically
-    # to control the test and make sure that they are no side
-    # effects on more simple checks
+  syncs:
+    - name: read
+      class: BaseReadSync
+      frequency: 100.0
+      group: devices
+      registers: ['current_pos', 'current_speed', 'current_load']
+      # we specifically want the loops not to start automatically
+      # to control the test and make sure that they are no side
+      # effects on more simple checks
 
-  - name: write
-    class: BaseWriteSync
-    frequency: 100.0
-    group: devices
-    registers: ['desired_pos', 'desired_speed', 'desired_load']
-    # to speed up testing
-    review: 0.2
-    auto: False
-    # we specifically want the loops not to start automatically
-    # to control the test and make sure that they are no side
-    # effects on more simple checks
+    - name: write
+      class: BaseWriteSync
+      frequency: 100.0
+      group: devices
+      registers: ['desired_pos', 'desired_speed', 'desired_load']
+      # to speed up testing
+      review: 0.2
+      auto: False
+      # we specifically want the loops not to start automatically
+      # to control the test and make sure that they are no side
+      # effects on more simple checks

--- a/tests/dummy_robot.yml
+++ b/tests/dummy_robot.yml
@@ -12,13 +12,13 @@ dummy:
       auto: False
 
   devices:
-    - name: d01
+    d01:
       class: BaseDevice
       bus: busA
       id: 1
       model: DUMMY
 
-    - name: d02
+    d02:
       class: BaseDevice
       bus: busA
       id: 2
@@ -26,13 +26,13 @@ dummy:
       auto: False
 
       # this is not in syncs
-    - name: d03
+    d03:
       class: BaseDevice
       bus: busA
       id: 3
       model: DUMMY
 
-    - name: d04
+    d04:
       class: BaseDevice
       bus: busB
       id: 4

--- a/tests/dummy_robot.yml
+++ b/tests/dummy_robot.yml
@@ -39,7 +39,7 @@ dummy:
       model: DUMMY
 
   joints:
-    - name: pan
+    pan:
       class: JointPVL
       device: d01
       pos_read: current_pos
@@ -52,7 +52,7 @@ dummy:
       min: -30.0
       max: 30.0
 
-    - name: tilt
+    tilt:
       class: JointPVL
       device: d02
       pos_read: current_pos

--- a/tests/dynamixel_robot.yml
+++ b/tests/dynamixel_robot.yml
@@ -2,7 +2,7 @@
 #
 dynamixel:
   buses:
-    - name: ttys1
+    ttys1:
       class: MockDynamixelBus
       port: /dev/ttys1
       baudrate: 19200

--- a/tests/dynamixel_robot.yml
+++ b/tests/dynamixel_robot.yml
@@ -1,17 +1,18 @@
 # robot defintion file for running automated tests
 #
-buses:
-  - name: ttys1
-    class: MockDynamixelBus
-    port: /dev/ttys1
-    baudrate: 19200
-    protocol: 2.0
-    auto: True
+dynamixel:
+  buses:
+    - name: ttys1
+      class: MockDynamixelBus
+      port: /dev/ttys1
+      baudrate: 19200
+      protocol: 2.0
+      auto: True
 
-devices:
-  - name: d11
-    class: DynamixelDevice
-    bus: ttys1
-    id: 11
-    model: XL-320
-    auto: True
+  devices:
+    - name: d11
+      class: DynamixelDevice
+      bus: ttys1
+      id: 11
+      model: XL-320
+      auto: True

--- a/tests/dynamixel_robot.yml
+++ b/tests/dynamixel_robot.yml
@@ -10,7 +10,7 @@ dynamixel:
       auto: True
 
   devices:
-    - name: d11
+    d11:
       class: DynamixelDevice
       bus: ttys1
       id: 11


### PR DESCRIPTION
Instead of list of things (buses, devices, etc.) we now use a dictionary.
This simplifies the handling of 'name' because it is mandatory to maintain if you create a dictionary.
The changes are applied to the device definition too (registers).