### PR TITLE
I2c module and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Roboglia
 
+[![Master Version](https://img.shields.io/badge/master-0.0.11-blue)](https://img.shields.io/badge/master-0.0.11-blue)
 [![PyPI version](https://badge.fury.io/py/roboglia.svg)](https://badge.fury.io/py/roboglia)
+![GitHub issues](https://img.shields.io/github/issues/sonelu/roboglia)
+
 [![Build Status](https://travis-ci.com/sonelu/roboglia.svg?branch=master)](https://travis-ci.com/sonelu/roboglia)
 [![Documentation Status](https://readthedocs.org/projects/roboglia/badge/?version=latest)](https://roboglia.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/sonelu/roboglia/branch/master/graph/badge.svg)](https://codecov.io/gh/sonelu/roboglia)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
+# Roboglia
+
+[![PyPI version](https://badge.fury.io/py/roboglia.svg)](https://badge.fury.io/py/roboglia)
 [![Build Status](https://travis-ci.com/sonelu/roboglia.svg?branch=master)](https://travis-ci.com/sonelu/roboglia)
 [![Documentation Status](https://readthedocs.org/projects/roboglia/badge/?version=latest)](https://roboglia.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/sonelu/roboglia/branch/master/graph/badge.svg)](https://codecov.io/gh/sonelu/roboglia)
-
-# Roboglia
 
 ``roboglia`` is a framework that helps developers with the setup of robots
 in a more reusable fashion. Most of the times the creation of robots involve
@@ -12,7 +13,7 @@ activities.
 
 The name `roboglia` is derived from the glial cells present in the brian.
 Their role is to support the neurons' functions by supplying them
-with nutirients, energy and disposing of waste. The analogy is that ``roboglia``
+with nutrients, energy and disposing of waste. The analogy is that ``roboglia``
 provides this boring, but very complex activity of putting together the specific
 functions of the physical devices used in robots in order to provide a more
 accessible high-level representation of the robot for the use of the "smart"
@@ -79,7 +80,7 @@ There is also an epub version that can be accessed
 ## Contribution
 
 We are very receptive for contributions. Please clone the repository and
-sumbit pull requests with the desired contrbution. They will be moderated and,
+submit pull requests with the desired contribution. They will be moderated and,
 if they add values to the users, they will be integrated. Please note that
 the [Travis CI](https://travis-ci.com) integration will perform the following
 two tests on the pull requests:
@@ -92,12 +93,12 @@ two tests on the pull requests:
 
       sudo python setup.py install
       cd tests
-      pyton all_tests.py
+      python all_tests.py
 
   Make sure that there are no errors issued by the unit tests. If you created
   new classes or new functions that are not covered by testing, then you will
   also need to write a test class or add a test method in an exiting class
-  to test that functionlity and submit those changes too.
+  to test that functionality and submit those changes too.
 
 * it will check PEP8 on the Python code using flake8. You should install
   (if you don't have it already) on your machine and run this (from the
@@ -118,7 +119,7 @@ in the pull request.
 
 If you create new Python files please add the copyright comments as they are
 included in the other files. Make sure you update your name at the top, we want
-people to recieve the creadit for their work. Similarly, if you change an
+people to receive the credit for their work. Similarly, if you change an
 existing file feel free to add your name at the top of the file.
 
 ## Showcasing your robot
@@ -127,7 +128,7 @@ If you use ``roboglia`` in your project we will like to hear about it and
 we will showcase it on this page. Please
 [open an issue](https://github.com/sonelu/roboglia/issues/new) with title
 "Showcase of robot" and provide us with information about your robot. You can
-send us links to the documentaion or code of the robot and one picture
+send us links to the documentation or code of the robot and one picture
 (link to an public one) that we could use in the showcase. If you want to
 provide an email address for contact we will be more than happy to include
 that too.

--- a/roboglia/base/__init__.py
+++ b/roboglia/base/__init__.py
@@ -2,9 +2,8 @@ from ..utils.factory import register_class
 
 from .bus import BaseBus                        # noqa: 401
 from .bus import FileBus                        # noqa: 401
-from .bus import ShareableBus                   # noqa: 401
-from .bus import ShareableFileBus               # noqa: 401
-
+from .bus import SharedBus                      # noqa: 401
+from .bus import SharedFileBus                  # noqa: 401
 
 from .register import BaseRegister              # noqa: 401
 from .register import BoolRegister              # noqa: 401
@@ -27,7 +26,7 @@ from .sync import BaseWriteSync                 # noqa: 401
 from .robot import BaseRobot                    # noqa: 401
 
 register_class(FileBus)
-register_class(ShareableFileBus)
+register_class(SharedFileBus)
 
 register_class(BaseRegister)
 register_class(RegisterWithConversion)

--- a/roboglia/base/bus.py
+++ b/roboglia/base/bus.py
@@ -26,7 +26,7 @@ class BaseBus():
     """A base abstract class for handling an arbitrary bus.
 
     You will normally subclass ``BaseBus`` and define particular functionality
-    specific to the bus by impementing the methods of the ``BaseBus``.
+    specific to the bus by implementing the methods of the ``BaseBus``.
     This class only stores the name of the bus and the access to the
     physical object. Your subclass can add additional attributes and
     methods to deal with the particularities of the real bus represented.
@@ -34,7 +34,7 @@ class BaseBus():
     Args:
         init_dict (dict): The dictionary used to initialize the bus.
 
-    The following keys are exepcted in the dictionary:
+    The following keys are expected in the dictionary:
 
     - ``name``: the name of the bus
     - ``port``: the port used by the bus
@@ -48,7 +48,7 @@ class BaseBus():
         KeyError: if ``port`` not supplied
     """
     def __init__(self, init_dict):
-        # alredy checked by robot
+        # already checked by robot
         self.__name = init_dict['name']
         self.__robot = init_dict['robot']
         check_key('port', init_dict, 'bus', self.__name, logger)
@@ -79,31 +79,31 @@ class BaseBus():
         return self.__auto_open
 
     def open(self):
-        """Opens the actual physical bus. Must be overriden by the
+        """Opens the actual physical bus. Must be overridden by the
         subclass.
         """
         raise NotImplementedError
 
     def close(self):
-        """Closes the actual physical bus. Must be overriden by the
+        """Closes the actual physical bus. Must be overridden by the
         subclass.
         """
         raise NotImplementedError
 
     @property
     def is_open(self):
-        """Returns `True` or `False` if the bus is open. Must be overriden
+        """Returns `True` or `False` if the bus is open. Must be overridden
         by the subclass.
         """
         raise NotImplementedError
 
     def read(self, dev, reg):
-        """Reads one standrd information from the bus. Must be overwriden.
+        """Reads one standard information from the bus. Must be overridden.
         """
         raise NotImplementedError
 
     def write(self, dev, reg, val):
-        """Writes one standrd information from the bus. Must be overwriden.
+        """Writes one standard information from the bus. Must be overridden.
         """
         raise NotImplementedError
 
@@ -111,7 +111,7 @@ class BaseBus():
 class FileBus(BaseBus):
     """A bus that writes to a file with cache.
 
-    Read returns the last writen data. Provided for testing purposes.
+    Read returns the last written data. Provided for testing purposes.
 
     Args:
         init_dict (dict): the initialization dictionary. Same parameters
@@ -147,13 +147,13 @@ class FileBus(BaseBus):
 
         Args:
             dev (obj): is the device that is writing
-            reg (obj): is the regoster object that is written
-            value (int): is the value beein written.
+            reg (obj): is the register object that is written
+            value (int): is the value beeing written.
 
         Raises:
-            the method intercept the raise erros from writing to the
+            the method intercept the raise errors from writing to the
             physical file and converts them to errors in the log file
-            so that the rest of the program can continue uninterupted.
+            so that the rest of the program can continue uninterrupted.
 
         The method will update the buffer with the value provided then
         will log the write on the file. A flush() is performed in case
@@ -179,15 +179,15 @@ class FileBus(BaseBus):
 
         Args:
             dev (obj): the device being read
-            reg (obj): register obhject being read
+            reg (obj): register object being read
 
         Returns:
             int : the value from the requested register
 
         Raises:
-            the method intercept the raise erros from writing to the
+            the method intercept the raise errors from writing to the
             physical file and converts them to errors in the log file
-            so that the rest of the program can continue uninterupted.
+            so that the rest of the program can continue uninterrupted.
 
         The method will try to read from the buffer the value. If there
         is no value in the buffer it will be defaulted from the register's
@@ -220,30 +220,10 @@ class FileBus(BaseBus):
         return result
 
 
-class ShareableBus():
-    """A class that controls access to shared resources when used in
-    multithreaded programs.
+class SharedBus():
 
-    Args:
-        init_dict (dict): The dictionary used to initialize the shareable.
-
-    The following keys are optional in the dictionary:
-
-    - ``timeout``: the time in seconds to wait to access the object;
-      defaults to 0.5 (s)
-
-    .. warning::
-
-        The user of a class that implements Shareable should be careful
-        when calling the :py:method:`stop_using`. Only the thered that
-        called :py:method:`can_use` should call :py:method:`stop_using`
-        when the processing is finished, and also should make sure that
-        it minimized the amount of time the resource is blocked.
-
-    Raises:
-        ValueError: if ``timeout`` is supplied and not a float
-    """
-    def __init__(self, init_dict):
+    def __init__(self, BusClass, init_dict):
+        self.__main_bus = BusClass(init_dict)
         self.__timeout = init_dict.get('timeout', 0.5)
         check_type(self.__timeout, float, 'bus', init_dict['name'], logger)
         if self.__timeout > 0.5:
@@ -251,11 +231,16 @@ class ShareableBus():
                            f'{init_dict["name"]} might be excessive.')
         self.__lock = threading.Lock()
 
+    @property
+    def timeout(self):
+        """Returns the timeout for requesting access to lock."""
+        return self.__timeout
+
     def can_use(self):
-        """Tries to aquire the resource on behalf of the caller.
+        """Tries to acquire the resource on behalf of the caller.
 
         Returns:
-            bool: ``True`` if managed to aquire the resource, ``False`` if
+            bool: ``True`` if managed to acquire the resource, ``False`` if
                   not. It is the responsibility of the caller to decide what
                   to do in case there is a ``False`` return including
                   logging or Raising.
@@ -267,77 +252,39 @@ class ShareableBus():
         self.__lock.release()
 
     def naked_read(self, dev, reg):
-        """Placeholder to be implemented by subclass."""
-        raise NotImplementedError
+        """Calls the main bus without invoking the lock."""
+        return self.__main_bus.read(dev, reg)
 
     def naked_write(self, dev, reg, value):
-        """Placeholder to be implmemented by subclass."""
-        raise NotImplementedError
-
-
-class ShareableFileBus(FileBus, ShareableBus):
-    """A FileBus that can be used in multithreaded environment.
-
-    Includes the functionality of a :py:class:`ShareableBus` in a
-    :py:class:`FileBus`. The :py:method:`write` and :py:method:`read` methods
-    are wrapped around in :py:method:`can_use` and :py:method:`stop_using`
-    to provide the exclusive access.
-
-    In addition, two methods :py:method:`naked_write` and
-    :py:method:`naked_read` are provided so that classes that want sequence
-    of read / writes can do that more efficiently without accessing the
-    lock every time. They simply invoke the *unsafe* methods
-    :py:method:Filebus.`write` and :py:method:Filebus.`read` from the
-    :py:class:`FileBus` class.
-
-    .. warning::
-
-        If you are using :py:method:`naked_write` and :py:method:`naked_read`
-        you **must** ensure that you wrap them in :py:method:`can_use` and
-        :py:method:`stop_using` in the calling code.
-
-    """
-    def __init__(self, init_dict):
-        FileBus.__init__(self, init_dict)
-        ShareableBus.__init__(self, init_dict)
-
-    def write(self, dev, reg, value):
-        """Write to file in a sharead environment.
-        If the method fails to aquire the lock it will log as an error
-        but will not raise an Exception.
-        """
-        if self.can_use():
-            super().write(dev, reg, value)
-            self.stop_using()
-        else:
-            logger.error(f'failed to aquire bus {self.name}')
-
-    def naked_write(self, dev, reg, value):
-        """Provided for efficient sequence write.
-        Simply calls the :py:method:FileBus.`write` method.
-        """
-        super().write(dev, reg, value)
+        """Calls the main bus without invoking the lock."""
+        self.__main_bus.write(dev, reg, value)
 
     def read(self, dev, reg):
-        """Read from file in a sharead environment.
-        If the method fails to aquire the lock it will log as an error
-        but will not raise an Exception. Will return None in this case.
-
-        Returns:
-            (int) the value from file or None is failing to read or
-            aquire the lock.
-
-        """
+        """Wraps the main bus call in a request for lock."""
         if self.can_use():
-            value = super().read(dev, reg)
+            value = self.__main_bus.read(dev, reg)
             self.stop_using()
             return value
         else:
-            logger.error(f'failed to aquire bus {self.name}')
+            logger.error(f'failed to acquire bus {self.__main_bus.name}')
             return None
 
-    def naked_read(self, dev, reg):
-        """Provided for efficient sequence read.
-        Simply calls the :py:method:FileBus.`read` method.
-        """
-        return super().read(dev, reg)
+    def write(self, dev, reg, value):
+        """Wraps the main bus call in a request for lock."""
+        if self.can_use():
+            self.__main_bus.write(dev, reg, value)
+            self.stop_using()
+        else:
+            logger.error(f'failed to acquire bus {self.__main_bus.name}')
+
+    def __getattr__(self, name):
+        return getattr(self.__main_bus, name)
+
+
+class SharedFileBus(SharedBus):
+
+    def __init__(self, init_dict):
+        super().__init__(FileBus, init_dict)
+
+    def __str__(self):
+        return FileBus.__str__(self)

--- a/roboglia/base/device.py
+++ b/roboglia/base/device.py
@@ -26,7 +26,7 @@ class BaseDevice():
     """A base virtual class for all devices.
 
     A BaseDevice is a surrogate representation of an actual device,
-    characterised by a number of internal registers that can be read or
+    characterized by a number of internal registers that can be read or
     written to by the means of a coomunication bus.
     Any device is based on a `model` that identifies the `.device` file
     describing the structure of the device (the registers).
@@ -34,7 +34,7 @@ class BaseDevice():
     Args:
         init_dict (dict): The dictionary used to initialize the joint.
 
-    The following keys are exepcted in the dictionary:
+    The following keys are expected in the dictionary:
 
     - ``name``: the name of the joint
     - ``bus``: the bus object where the device is attached to
@@ -65,6 +65,7 @@ class BaseDevice():
         with open(model_file, 'r') as f:
             model_ini = yaml.load(f, Loader=yaml.FullLoader)
         self.__registers = {}
+        self.__reg_by_addr = {}
         for reg_name, reg_info in model_ini['registers'].items():
             # add name to the dictionary
             reg_info['name'] = reg_name
@@ -74,6 +75,7 @@ class BaseDevice():
             new_register = reg_class(reg_info)
             self.__dict__[reg_info['name']] = new_register
             self.__registers[reg_info['name']] = new_register
+            self.__reg_by_addr[reg_info['address']] = new_register
         self.__auto_open = init_dict.get('auto', True)
         check_options(self.__auto_open, [True, False], 'device',
                       self.name, logger)
@@ -89,10 +91,7 @@ class BaseDevice():
         return self.__registers
 
     def register_by_address(self, address):
-        for register in self.registers.values():
-            if register.address == address:
-                return register
-        return None
+        return self.__reg_by_addr.get(address, None)
 
     @property
     def dev_id(self):
@@ -126,7 +125,7 @@ class BaseDevice():
 
     def default_register(self):
         """Default register for the device in case is not explicitly
-        provided in the device defition file.
+        provided in the device definition file.
         Subclasses of `BaseDevice` can overide the method to derive their
         own class.
         """

--- a/roboglia/base/devices/DUMMY.yml
+++ b/roboglia/base/devices/DUMMY.yml
@@ -82,7 +82,7 @@ registers:
 
     # not really often in practice as RW
     # here for testing
-  writtable_current_load:
+  writeable_current_load:
     class: RegisterWithThreshold
     address: 95
     size: 2

--- a/roboglia/base/register.py
+++ b/roboglia/base/register.py
@@ -29,7 +29,7 @@ class BaseRegister():
     Args:
         init_dict (dict): The dictionary used to initialize the register.
 
-    The following keys are exepcted in the dictionary:
+    The following keys are expected in the dictionary:
 
     - ``name``: the name of the register
     - ``device``: the device where the register is attached to
@@ -217,7 +217,7 @@ class RegisterWithThreshold(BaseRegister):
     a threshold between negative and positive values::
 
         if internal >= threshold:
-            external = (internal - threashold) / factor
+            external = (internal - threshold) / factor
         else:
             external = - internal / factor
 
@@ -232,7 +232,7 @@ class RegisterWithThreshold(BaseRegister):
         init_dict (dict): The dictionary used to initialize the register.
 
     In addition to the fields used in :py:class:`BaseRegister`, the following
-    keys are exepcted in the dictionary:
+    keys are expected in the dictionary:
 
     - ``factor``: a factor used for conversion (float)
     - ``threshold``: a threshold that separates the positive from negative

--- a/roboglia/base/robot.py
+++ b/roboglia/base/robot.py
@@ -65,6 +65,7 @@ class BaseRobot():
     def __init_devices(self, init_dict):
         """Called by ``__init__`` to parse and instantiate devices."""
         self.__devices = {}
+        self.__dev_by_id = {}
         logger.info('Initializing devices...')
         check_key('devices', init_dict, 'robot', '', logger)
         for dev_name, dev_info in init_dict['devices'].items():
@@ -81,6 +82,7 @@ class BaseRobot():
             dev_class = get_registered_class(dev_info['class'])
             new_dev = dev_class(dev_info)
             self.__devices[dev_name] = new_dev
+            self.__dev_by_id[dev_info['id']] = new_dev
             logger.debug(f'\tdevice {dev_name} added')
 
     def __init_joints(self, init_dict):
@@ -173,10 +175,7 @@ class BaseRobot():
             (BaseRegister): the register with that ID in the device. If
                 no register with that ID exists, returns ``None``.
         """
-        for device in self.devices.values():
-            if device.dev_id == dev_id:
-                return device
-        return None
+        return self.__dev_by_id.get(dev_id, None)
 
     @property
     def joints(self):

--- a/roboglia/base/robot.py
+++ b/roboglia/base/robot.py
@@ -29,7 +29,7 @@ class BaseRobot():
     def __init__(self, init_dict):
         logger.info('***** Initializing robot *************')
         if len(init_dict) > 1:
-            logger.warning(f'Only the first robot will be considered.')
+            logger.warning('Only the first robot will be considered.')
         self.__name = list(init_dict)[0]
         components = init_dict[self.__name]
         self.__init_buses(components)
@@ -49,7 +49,7 @@ class BaseRobot():
     def __init_buses(self, init_dict):
         """Called by ``__init__`` to parse and instantiate buses."""
         self.__buses = {}
-        logger.info(f'Initializing buses...')
+        logger.info('Initializing buses...')
         check_key('buses', init_dict, 'robot', self.name, logger)
         for bus_name, bus_info in init_dict['buses'].items():
             # add the name in the dict
@@ -65,7 +65,7 @@ class BaseRobot():
     def __init_devices(self, init_dict):
         """Called by ``__init__`` to parse and instantiate devices."""
         self.__devices = {}
-        logger.info(f'Initializing devices...')
+        logger.info('Initializing devices...')
         check_key('devices', init_dict, 'robot', '', logger)
         for dev_name, dev_info in init_dict['devices'].items():
             # add the name in the dev_info
@@ -86,7 +86,7 @@ class BaseRobot():
     def __init_joints(self, init_dict):
         """Called by ``__init__`` to parse and instantiate joints."""
         self.__joints = {}
-        logger.info(f'Initializing joints...')
+        logger.info('Initializing joints...')
         for joint_name, joint_info in init_dict.get('joints', {}).items():
             # add the name in the joint_info
             joint_info['name'] = joint_name
@@ -108,7 +108,7 @@ class BaseRobot():
     def __init_groups(self, init_dict):
         """Called by ``__init__`` to parse and instantiate groups."""
         self.__groups = {}
-        logger.info(f'Initializing groups...')
+        logger.info('Initializing groups...')
         for grp_name, grp_info in init_dict.get('groups', {}).items():
             new_grp = set()
             # groups of devices
@@ -132,7 +132,7 @@ class BaseRobot():
     def __init_syncs(self, init_dict):
         """Called by ``__init__`` to parse and instantiate syncs."""
         self.__syncs = {}
-        logger.info(f'Initializing syncs...')
+        logger.info('Initializing syncs...')
         for sync_name, sync_info in init_dict.get('syncs', {}).items():
             sync_info['name'] = sync_name
             check_key('group', sync_info, 'sync', sync_name, logger)
@@ -202,28 +202,28 @@ class BaseRobot():
 
         """
         logger.info('***** Starting robot *****************')
-        logger.info(f'Opening buses...')
+        logger.info('Opening buses...')
         for bus in self.buses.values():
             if bus.auto_open:
                 logger.debug(f'--> Opening bus: {bus.name}')
                 bus.open()
             else:
                 logger.debug(f'--> Opening bus: {bus.name} - skipped')
-        logger.info(f'Opening devices...')
+        logger.info('Opening devices...')
         for device in self.devices.values():
             if device.auto_open:
                 logger.debug(f'--> Opening device: {device.name}')
                 device.open()
             else:
                 logger.debug(f'--> Opening device: {device.name} - skipped')
-        logger.info(f'Activating joints...')
+        logger.info('Activating joints...')
         for joint in self.joints.values():
             if joint.auto_activate:
                 logger.debug(f'--> Activating joint: {joint.name}')
                 joint.active = True
             else:
                 logger.debug(f'--> Activating joint: {joint.name} - skipped')
-        logger.info(f'Starting syncs...')
+        logger.info('Starting syncs...')
         for sync in self.syncs.values():
             if sync.auto_start:
                 logger.debug(f'--> Starting sync: {sync.name}')
@@ -241,17 +241,17 @@ class BaseRobot():
 
         """
         logger.info('***** Stopping robot *****************')
-        logger.info(f'Stopping syncs...')
+        logger.info('Stopping syncs...')
         for sync in self.syncs.values():
             logger.debug(f'--> Stopping sync: {sync.name}')
             sync.stop()
         for joint in self.joints.values():
             logger.debug(f'--> Deactivating joint: {joint.name}')
-        logger.info(f'Closing devices...')
+        logger.info('Closing devices...')
         for device in self.devices.values():
             logger.debug(f'--> Closing device: {device.name}')
             device.close()
-        logger.info(f'Closing buses...')
+        logger.info('Closing buses...')
         for bus in self.buses.values():
             logger.debug(f'--> Closing bus: {bus.name}')
             bus.close()

--- a/roboglia/base/sync.py
+++ b/roboglia/base/sync.py
@@ -135,6 +135,28 @@ class BaseSync(BaseLoop):
                     logger.debug(f'setting register {register} of device '
                                  f'{device.name} sync=True')
 
+    def get_register_range(self):
+        """Determines the start address of the range of registers and the
+        whole length. Registers do not need to be order, but be careful
+        that not all communication protocols can support gaps in the
+        bulk read of registers.
+        """
+        start_address = 65536
+        last_address = 0
+        last_length = 0
+        length = 0
+        # pick the first device; we expect all to have the same registers
+        device = self.devices[0]
+        for reg_name in self.registers:
+            register = getattr(device, reg_name)
+            if register.address < start_address:
+                start_address = register.address
+            if register.address > last_address:
+                last_address = register.address
+                last_length = register.size
+        length = last_address + last_length - start_address
+        return start_address, length
+
     def start(self):
         """Checks that the bus is open before calling the inherited
         ``start``."""

--- a/roboglia/base/sync.py
+++ b/roboglia/base/sync.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 class BaseSync(BaseLoop):
     """Base processing for a sync loop.
 
-    This class is internded to be subclassed to provide specific functionality.
+    This class is intended to be subclassed to provide specific functionality.
     It only parses the common elements that a sync loop would need:
     the devices (provided by a group) and registers (provided by a list).
     It will check that the provided devices are on the same bus and that
@@ -34,7 +34,7 @@ class BaseSync(BaseLoop):
         init_dict (dict): The dictionary used to initialize the sync.
 
     In addition to the keys expected by the :py:class:`BaseLoop` The following
-    keys are exepcted in the dictionary:
+    keys are expected in the dictionary:
 
     - ``group``: the set with the devices used by sync; normally the robot
       constructor replaces the name of the group from YAML file with the
@@ -119,7 +119,7 @@ class BaseSync(BaseLoop):
         return one_bus
 
     def process_registers(self):
-        """Checks that the supplied registers are avaialable in all
+        """Checks that the supplied registers are available in all
         devices and sets the ``sync`` attribute to ``True`` if not already
         set."""
         for device in self.__devices:
@@ -169,7 +169,7 @@ class BaseReadSync(BaseSync):
                                        f'of device {device.name}')
             self.bus.stop_using()
         else:
-            logger.error(f'failed to aquire buss {self.bus.name}')
+            logger.error(f'failed to acquire buss {self.bus.name}')
 
 
 class BaseWriteSync(BaseSync):
@@ -190,4 +190,4 @@ class BaseWriteSync(BaseSync):
                     self.bus.naked_write(device, reg, reg.int_value)
             self.bus.stop_using()
         else:
-            logger.error(f'failed to aquire buss {self.bus.name}')
+            logger.error(f'failed to acquire buss {self.bus.name}')

--- a/roboglia/base/sync.py
+++ b/roboglia/base/sync.py
@@ -107,7 +107,7 @@ class BaseSync(BaseLoop):
         buses = set([device.bus for device in self.__devices])
         if len(buses) > 1:
             mess = f'Devices used for sync {self.name} should be ' + \
-                   f'connected to a single bus.'
+                   'connected to a single bus.'
             logger.critical(mess)
             raise ValueError(mess)
         elif len(buses) == 0:

--- a/roboglia/base/thread.py
+++ b/roboglia/base/thread.py
@@ -38,7 +38,7 @@ class BaseThread():
     run for an indefinite time, and later are closed when the owner signals.
     """
     def __init__(self, init_dict):
-        # name shoukld have been checkd by the robot
+        # name should have been checked by the robot
         self.__name = init_dict['name']
         self.__started = threading.Event()
         self.__paused = threading.Event()
@@ -95,7 +95,7 @@ class BaseThread():
         return self.__started.is_set() and self.__paused.is_set()
 
     def _wrapped_target(self):
-        """Wrapps the execution of the task between the setup() and
+        """Wraps the execution of the task between the setup() and
         teardown() and sets / resets the events."""
         try:
             self.setup()
@@ -116,6 +116,7 @@ class BaseThread():
             self.stop()
         self.__thread = threading.Thread(target=self._wrapped_target)
         self.__thread.daemon = True
+        self.__thread.name = self.name
         self.__thread.start()
 
         if wait and (threading.current_thread() != self.__thread):
@@ -128,7 +129,7 @@ class BaseThread():
 
     def stop(self, wait=True):
         """Sends the stopping signal to the thread. By default waits for
-        the thred to finish."""
+        the thread to finish."""
         if self.started:
             self.__started.clear()
             self.__paused.clear()
@@ -169,9 +170,9 @@ class BaseLoop(BaseThread):
     - ``warning``: indicates a threshold in range [0..1] indicating when
       warnings should be logged to the logger in case the execution
       frequency is bellow the target. A 0.8 value indicates the real
-      execution is less than 0.8 * taget_frequency. The statistic is
+      execution is less than 0.8 * target_frequency. The statistic is
       calculated over a number of runs equal to the frequency (ex. if
-      the frequency is 10 Hz the statistics will be claculated after
+      the frequency is 10 Hz the statistics will be calculated after
       10 execution cycles and then reset). If not provided the
       value 0.9 (90%) will be used.
     - ``throttle``: is a float (small) that is used by the monitoring of
@@ -194,7 +195,7 @@ class BaseLoop(BaseThread):
         check_type(self.__throttle, float, 'loop', self.name, logger)
         self.__review = init_dict.get('review', 1.00)
         check_type(self.__review, float, 'loop', self.name, logger)
-        # to keeep statistics
+        # to keep statistics
         self.__exec_counts = 0
         self.__last_count_reset = None
 
@@ -210,7 +211,7 @@ class BaseLoop(BaseThread):
 
     @property
     def warning(self):
-        """Control the warning level for the warning message, the **seter**
+        """Control the warning level for the warning message, the **setter**
         is smart: if the value is larger than 2 it will assume it is a
         percentage and divied it by 100 and ignore if the number is higher
         than 110.

--- a/roboglia/dynamixel/__init__.py
+++ b/roboglia/dynamixel/__init__.py
@@ -7,8 +7,8 @@ from .register import DynamixelXLBaudRateRegister
 from .device import DynamixelDevice
 
 from .bus import DynamixelBus
-from .bus import ShareableDynamixelBus
-from .bus import MockDynamixelBus
+from .bus import SharedDynamixelBus
+# from .bus import MockDynamixelBus
 
 from .sync import DynamixelSyncReadLoop
 from .sync import DynamixelSyncWriteLoop
@@ -22,8 +22,8 @@ register_class(DynamixelXLBaudRateRegister)
 register_class(DynamixelDevice)
 
 register_class(DynamixelBus)
-register_class(ShareableDynamixelBus)
-register_class(MockDynamixelBus)
+register_class(SharedDynamixelBus)
+# register_class(MockDynamixelBus)
 
 register_class(DynamixelSyncReadLoop)
 register_class(DynamixelSyncWriteLoop)

--- a/roboglia/dynamixel/bus.py
+++ b/roboglia/dynamixel/bus.py
@@ -16,10 +16,10 @@
 import logging
 import random
 
-import dynamixel_sdk
+from dynamixel_sdk import PacketHandler, PortHandler
 from serial import rs485
 
-from ..base import BaseBus, ShareableBus
+from ..base import BaseBus, SharedBus
 from ..utils import check_key, check_type, check_options
 
 logger = logging.getLogger(__name__)
@@ -33,12 +33,17 @@ class DynamixelBus(BaseBus):
     Args:
         init_dict (dict): The dictionary used to initialize the bus.
 
-    In addition to the keys that are required by the :py:class:BaseBus the
+    In addition to the keys that are required by the :py:class:`BaseBus` the
     following key must by provided:
 
     - ``baudrate``: communication speed for the bus (int)
     - ``protocol``: communication protocol for the bus; must be 1.0 or 2.0
-    - ``rs485``: activates RS485 protocol on the serial bus (bool)
+
+    Additional keys:
+    - ``rs485``: activates RS485 protocol on the serial bus (bool); default
+      is ``False``
+    - ``mock``: indicates to use mock bus for testing purposes; default is
+      ``False``
 
     Raises:
         KeyError: if any of the required keys are missing
@@ -56,32 +61,18 @@ class DynamixelBus(BaseBus):
         check_options(self.__rs485, [True, False], 'bus', self.name, logger)
         self.__port_handler = None
         self.__packet_handler = None
+        self.__mock = init_dict.get('mock', False)
+        check_options(self.__mock, [True, False], 'bus', self.name, logger)
 
     @property
     def port_handler(self):
         """The Dynamixel port handler for this bus."""
         return self.__port_handler
 
-    @port_handler.setter
-    def port_handler(self, ph):
-        if ph == 'MockBus' or ph is None:
-            self.__port_handler = ph
-        else:
-            raise ValueError('you can use the setter only with MockBus for '
-                             'testing purposes...')
-
     @property
     def packet_handler(self):
         """The Dynamixel packet handler for this bus."""
         return self.__packet_handler
-
-    @packet_handler.setter
-    def packet_handler(self, pkh):
-        if isinstance(pkh, MockPacketHandler) or pkh is None:
-            self.__packet_handler = pkh
-        else:
-            raise ValueError('you can use the setter only with '
-                             'MockPacketHandler for testing purpoises...')
 
     @property
     def protocol(self):
@@ -94,36 +85,50 @@ class DynamixelBus(BaseBus):
         return self.__baudrate
 
     def open(self):
-        """Opens the actual physical bus. Must be overriden by the
-        subclass.
+        """Allocates the port_handler and the packet_handler. If the
+        ``init_dict`` contains the attribute ``mock`` to ``True`` then
+        uses MockPacketHandler.
         """
-        self.__port_handler = dynamixel_sdk.PortHandler(self.port)
-        self.__port_handler.openPort()
-        self.__port_handler.setBaudRate(self.__baudrate)
-        if self.__rs485:
-            self.__port_handler.ser.rs485_mode = rs485.RS485Settings()
-            logger.info(f'bus {self.name} set in rs485 mode')
-        self.__packet_handler = dynamixel_sdk.PacketHandler(self.__protocol)
+        if self.__mock:
+            self.__port_handler = 'MockBus'
+            self.__packet_handler = MockPacketHandler(self.protocol,
+                                                      self.robot)
+        else:
+            self.__port_handler = PortHandler(self.port)
+            self.__port_handler.openPort()
+            self.__port_handler.setBaudRate(self.__baudrate)
+            if self.__rs485:
+                self.__port_handler.ser.rs485_mode = rs485.RS485Settings()
+                logger.info(f'bus {self.name} set in rs485 mode')
+            self.__packet_handler = PacketHandler(self.__protocol)
         logger.info(f'bus {self.name} opened')
 
     def close(self):
-        """Closes the actual physical bus. Must be overriden by the
-        subclass.
+        """Closes the actual physical bus.
         """
         if self.is_open:
             self.__packet_handler = None
-            self.__port_handler.closePort()
+            if not self.__mock:
+                self.__port_handler.closePort()
             self.__port_handler = None
             logger.info(f'bus {self.name} closed')
 
     @property
     def is_open(self):
-        """Returns `True` or `False` if the bus is open. Must be overriden
+        """Returns `True` or `False` if the bus is open. Must be overridden
         by the subclass.
         """
         return self.__port_handler is not None
 
     def ping(self, dxl_id):
+        """Performs a Dynamixel ``ping`` of a device.
+
+        Args:
+            dxl_id (int): the Dynamixel device number to be pinged.
+
+        Returns:
+            (bool): ``True`` if the device responded, ``False`` otherwise.
+        """
         if not self.is_open:
             logger.error('ping invoked with a bus not opened')
         else:
@@ -135,22 +140,34 @@ class DynamixelBus(BaseBus):
                 return False
 
     def scan(self, range=range(254)):
+        """Scans the devices on the bus.
+
+        Args:
+            range(int range): the range of devices to be cheked if they
+                exit on the bus. The method will call :py:method:`~ping`
+                for each ID in the list. By default the list is [0, 255).
+
+        Returns:
+            (list int): the list of IDs that have been successfully
+                identified on the bus. If none is found the list will be
+                empty.
+        """
         if not self.is_open:
             logger.error('scan invoked with a bus not opened')
         else:
             return [dxl_id for dxl_id in range if self.ping(dxl_id)]
 
     def read(self, dev, reg):
-        """Depending on the size of the register is calls the corresponding
+        """Depending on the size of the register calls the corresponding
         TxRx function from the packet handler.
         If the result is ok (communication error and dynamixel error are both
-        0) then the obtained value is returned. Otherwise it will throw a
-        ConnectionError. Callers shoud intercept the exception if they
-        want to control it.
+        0) then the obtained value is returned. Communication and data
+        errors are logged and no exceptions are raised.
         """
         if not self.is_open:
             logger.error(f'attempt to use closed bus {self.name}')
         else:
+
             # select the function by the size of register
             if reg.size == 1:
                 function = self.__packet_handler.read1ByteTxRx
@@ -159,40 +176,50 @@ class DynamixelBus(BaseBus):
             elif reg.size == 4:
                 function = self.__packet_handler.read4ByteTxRx
             else:
-                raise ValueError(f'unexpected size {reg.size} for register '
-                                 f'{reg.name} of device {dev.name}')
+                logger.critical(f'unexpected size {reg.size} for register '
+                                f'{reg.name} of device {dev.name}')
+                return None
+
             # call the function
-            res, cerr, derr = function(self.__port_handler,
-                                       dev.dev_id, reg.address)
+            try:
+                res, cerr, derr = function(self.__port_handler,
+                                           dev.dev_id, reg.address)
+            except Exception as e:
+                logger.error(f'Exception raised while reading bus {self.name}'
+                             f' device {dev.name} register {reg.name}')
+                logger.error(str(e))
+                return None
+
+            # success call - log DEBUG
             logger.debug(f'[readXByteTxRx] dev={dev.dev_id} '
                          f'reg={reg.address}: '
                          f'{res} (cerr={cerr}, derr={derr})')
             # process result
             if cerr != 0:
                 # communication error
-                err_descr = self.__packet_handler.getTxRxResult(cerr)
+                err_desc = self.__packet_handler.getTxRxResult(cerr)
                 logger.error(f'[bus {self.name}] device {dev.name}, '
-                             f'register {reg.name}: {err_descr}')
+                             f'register {reg.name}: {err_desc}')
                 return None
             else:
                 if derr != 0:
                     # device error
-                    err_descr = self.__packet_handler.getRxPacketError(derr)
+                    err_desc = self.__packet_handler.getRxPacketError(derr)
                     logger.warning(f'device {dev.name} responded with a '
-                                   f'return error: {err_descr}')
+                                   f'return error: {err_desc}')
                 else:
                     return res
 
     def write(self, dev, reg, value):
-        """Depending on the size of the register is calls the corresponding
+        """Depending on the size of the register calls the corresponding
         TxRx function from the packet handler.
-        If the result is not ok (communication error or dynamixel error are not
-        both 0) it will throw a ConnectionError. Callers shoud intercept the
-        exception if they want to control it.
+        Communication and data errors are logged and no exceptions are
+        raised.
         """
         if not self.is_open:
             logger.error(f'attempt to use closed bus {self.name}')
         else:
+
             # select function by register size
             if reg.size == 1:
                 function = self.__packet_handler.write1ByteTxRx
@@ -201,94 +228,62 @@ class DynamixelBus(BaseBus):
             elif reg.size == 4:
                 function = self.__packet_handler.write4ByteTxRx
             else:
-                raise ValueError(f'unexpected size {reg.size} for register '
-                                 f'{reg.name} of device {dev.name}')
+                logger.error(f'unexpected size {reg.size} for register '
+                             f'{reg.name} of device {dev.name}')
+                return None
+
             # execute the function
-            cerr, derr = function(self.__port_handler, dev.dev_id,
-                                  reg.address, value)
+            try:
+                cerr, derr = function(self.__port_handler, dev.dev_id,
+                                      reg.address, value)
+            except Exception as e:
+                logger.error(f'Exception raised while writing bus {self.name}'
+                             f' device {dev.name} register {reg.name}')
+                logger.error(str(e))
+                return None
+
+            # success call - log DEBUG
             logger.debug(f'[writeXByteTxRx] dev={dev.dev_id} '
                          f'reg={reg.address}: '
                          f'{value} (cerr={cerr}, derr={derr})')
             # process result
             if cerr != 0:
                 # communication error
-                err_descr = self.__packet_handler.getTxRxResult(cerr)
+                err_desc = self.__packet_handler.getTxRxResult(cerr)
                 logger.error(f'[bus {self.name}] device {dev.name}, '
-                             f'register {reg.name}: {err_descr}')
+                             f'register {reg.name}: {err_desc}')
             else:
                 if derr != 0:
                     # device error
-                    err_descr = self.__packet_handler.getRxPacketError(derr)
+                    err_desc = self.__packet_handler.getRxPacketError(derr)
                     logger.warning(f'device {dev.name} responded with a '
-                                   f'return error: {err_descr}')
+                                   f'return error: {err_desc}')
 
 
-class ShareableDynamixelBus(DynamixelBus, ShareableBus):
+class SharedDynamixelBus(SharedBus):
     """A DynamixelBus that can be used in multithreaded environment.
 
-    Includes the functionality of a :py:class:`ShareableBus` in a
-    :py:class:`DynamixelBus`. The :py:method:`write` and :py:method:`read`
-    methods are wrapped around in :py:method:`can_use` and
-    :py:method:`stop_using` to provide the exclusive access.
+    Includes the functionality of a :py:class:`SharedBus` in a
+    :py:class:`DynamixelBus`. The :py:method:`~write` and :py:method:`~read`
+    methods are wrapped around in :py:method:`~can_use` and
+    :py:method:`~stop_using` to provide the exclusive access.
 
-    In addition, two methods :py:method:`naked_write` and
-    :py:method:`naked_read` are provided so that classes that want sequence
+    In addition, two methods :py:method:`~naked_write` and
+    :py:method:`~naked_read` are provided so that classes that want sequence
     of read / writes can do that more efficiently without accessing the
     lock every time. They simply invoke the *unsafe* methods
-    :py:method:Filebus.`write` and :py:method:Filebus.`read` from the
-    :py:class:`DynamixelBus` class.
+    :py:method:DynamixelBus.`write` and :py:method:DynamixelBus.`read` from
+    the :py:class:`DynamixelBus` class.
 
     .. warning::
 
-        If you are using :py:method:`naked_write` and :py:method:`naked_read`
-        you **must** ensure that you wrap them in :py:method:`can_use` and
-        :py:method:`stop_using` in the calling code.
+        If you are using :py:method:`~naked_write` and :py:method:`~naked_read`
+        you **must** ensure that you wrap them in :py:method:`~can_use` and
+        :py:method:`~stop_using` in the calling code.
 
     """
     def __init__(self, init_dict):
-        DynamixelBus.__init__(self, init_dict)
-        ShareableBus.__init__(self, init_dict)
-
-    def write(self, dev, reg, value):
-        """Write to file in a sharead environment.
-        If the method fails to acquire the lock it will log as an error
-        but will not raise an Exception.
-        """
-        if self.can_use():
-            super().write(dev, reg, value)
-            self.stop_using()
-        else:
-            logger.error(f'failed to acquire bus {self.name}')
-
-    def naked_write(self, dev, reg, value):
-        """Provided for efficient sequence write.
-        Simply calls the :py:method:DynamixelBus.`write` method.
-        """
-        super().write(dev, reg, value)
-
-    def read(self, dev, reg):
-        """Read from file in a sharead environment.
-        If the method fails to acquire the lock it will log as an error
-        but will not raise an Exception. Will return None in this case.
-
-        Returns:
-            (int) the value from file or None is failing to read or
-            acquire the lock.
-
-        """
-        if self.can_use():
-            value = super().read(dev, reg)
-            self.stop_using()
-            return value
-        else:
-            logger.error(f'failed to acquire bus {self.name}')
-            return None
-
-    def naked_read(self, dev, reg):
-        """Provided for efficient sequence read.
-        Simply calls the :py:method:DynamixelBus.`read` method.
-        """
-        return super().read(dev, reg)
+        super().__init__(DynamixelBus, init_dict)
 
 
 class MockPacketHandler():
@@ -303,24 +298,20 @@ class MockPacketHandler():
         return self.__protocol
 
     def getTxRxResult(self, err):
-        ph = dynamixel_sdk.PacketHandler(self.__protocol)
+        ph = PacketHandler(self.__protocol)
         return ph.getTxRxResult(err)
 
     def getRxPacketError(self, err):
-        ph = dynamixel_sdk.PacketHandler(self.__protocol)
+        ph = PacketHandler(self.__protocol)
         return ph.getRxPacketError(err)
 
     def __common_writeTxRx(self, ph, dev_id, address, value):
         if random.random() < self.__err:
             return -3001, 0
         else:
-            for dev in self.__robot.devices.values():
-                if dev.dev_id == dev_id:
-                    break
-            for reg in dev.registers.values():
-                if reg.address == address:
-                    break
-            reg.int_value = value
+            # device = self.__robot.device_by_id(dev_id)
+            # reg = device.register_by_address(address)
+            # reg.int_value = value
             if random.random() < self.__err:
                 return 0, 4         # overheat
             else:
@@ -339,12 +330,8 @@ class MockPacketHandler():
         if random.random() < self.__err:
             return 0, -3001, 0
         else:
-            for dev in self.__robot.devices.values():
-                if dev.dev_id == dev_id:
-                    break
-            for reg in dev.registers.values():
-                if reg.address == address:
-                    break
+            device = self.__robot.device_by_id(dev_id)
+            reg = device.register_by_address(address)
             if random.random() < self.__err:
                 return reg.int_value, 0, 4      # overheat
             else:
@@ -386,7 +373,7 @@ class MockPacketHandler():
             return 0, -3001, 0
 
         # we're not going to check the device and register as we
-        # expect both to be avaialable since we checked them when
+        # expect both to be available since we checked them when
         # we setup the sync
         else:
             if self.__mode == 'sync':
@@ -432,32 +419,3 @@ class MockPacketHandler():
             if device.dev_id == dxl_id:
                 return device.model_number, 0, 0
         return 0, -3001, 0
-
-
-class MockDynamixelBus(ShareableDynamixelBus):
-
-    def __init__(self, init_dict):
-        super().__init__(init_dict)
-
-    def open(self):
-        """Opens the actual physical bus. Must be overriden by the
-        subclass.
-        """
-        self.port_handler = 'MockBus'
-        # self.port_handler.openPort()
-        # self.port_handler.setBaudRate(self.baudrate)
-        # if self.__rs485:
-        #     self.__port_handler.rs485_mode = rs485.RS485Settings()
-        #     logger.info(f'bus {self.name} set in rs485 mode')
-        self.packet_handler = MockPacketHandler(self.protocol,
-                                                self.robot)
-        logger.info(f'bus {self.name} opened')
-
-    def close(self):
-        """Closes the actual physical bus. Must be overriden by the
-        subclass.
-        """
-        if self.is_open:
-            self.packet_handler = None
-            self.port_handler = None
-            logger.info(f'bus {self.name} closed')

--- a/roboglia/dynamixel/bus.py
+++ b/roboglia/dynamixel/bus.py
@@ -176,9 +176,7 @@ class DynamixelBus(BaseBus):
             elif reg.size == 4:
                 function = self.__packet_handler.read4ByteTxRx
             else:
-                logger.critical(f'unexpected size {reg.size} for register '
-                                f'{reg.name} of device {dev.name}')
-                return None
+                raise NotImplementedError
 
             # call the function
             try:
@@ -228,9 +226,7 @@ class DynamixelBus(BaseBus):
             elif reg.size == 4:
                 function = self.__packet_handler.write4ByteTxRx
             else:
-                logger.error(f'unexpected size {reg.size} for register '
-                             f'{reg.name} of device {dev.name}')
-                return None
+                raise NotImplementedError
 
             # execute the function
             try:

--- a/roboglia/dynamixel/device.py
+++ b/roboglia/dynamixel/device.py
@@ -68,4 +68,6 @@ class DynamixelDevice(BaseDevice):
         for reg in self.registers.values():
             # only registers that are not flagged for sync replication
             if not reg.sync:
-                reg.int_value = self.read_register(reg)
+                value = self.read_register(reg)
+                if value is not None:
+                    reg.int_value 

--- a/roboglia/dynamixel/device.py
+++ b/roboglia/dynamixel/device.py
@@ -70,4 +70,4 @@ class DynamixelDevice(BaseDevice):
             if not reg.sync:
                 value = self.read_register(reg)
                 if value is not None:
-                    reg.int_value 
+                    reg.int_value

--- a/roboglia/dynamixel/sync.py
+++ b/roboglia/dynamixel/sync.py
@@ -97,7 +97,7 @@ class DynamixelSyncReadLoop(BaseSync):
     def __init__(self, init_dict):
         super().__init__(init_dict)
         if self.bus.protocol != 2.0:
-            mess = f'SyncRead only supported for Dynamixel Protocol 2.0.'
+            mess = 'SyncRead only supported for Dynamixel Protocol 2.0.'
             logger.critical(mess)
             raise ValueError(mess)
 
@@ -162,7 +162,7 @@ class DynamixelBulkWriteLoop(BaseSync):
     def __init__(self, init_dict):
         super().__init__(init_dict)
         if self.bus.protocol != 2.0:
-            mess = f'BulkWrite only supported for Dynamixel Protocol 2.0.'
+            mess = 'BulkWrite only supported for Dynamixel Protocol 2.0.'
             logger.critical(mess)
             raise ValueError(mess)
 

--- a/roboglia/i2c/__init__.py
+++ b/roboglia/i2c/__init__.py
@@ -1,5 +1,12 @@
 from ..utils import register_class
 
 from .bus import I2CBus
+from .bus import SharedI2CBus
+from .bus import MockSMBus                                  # noqa F401
+
+from .device import I2CDevice
 
 register_class(I2CBus)
+register_class(SharedI2CBus)
+
+register_class(I2CDevice)

--- a/roboglia/i2c/__init__.py
+++ b/roboglia/i2c/__init__.py
@@ -6,7 +6,13 @@ from .bus import MockSMBus                                  # noqa F401
 
 from .device import I2CDevice
 
+from .sync import I2CReadLoop
+from .sync import I2CWriteLoop
+
 register_class(I2CBus)
 register_class(SharedI2CBus)
 
 register_class(I2CDevice)
+
+register_class(I2CReadLoop)
+register_class(I2CWriteLoop)

--- a/roboglia/i2c/bus.py
+++ b/roboglia/i2c/bus.py
@@ -71,6 +71,7 @@ class I2CBus(BaseBus):
         """
         if not self.is_open:
             logger.error(f'attempted to read from a closed bus: {self.name}')
+            return None
         else:
             if reg.size == 1:
                 function = self.__i2cbus.read_byte_data
@@ -141,6 +142,8 @@ class MockSMBus(SMBus):
 
     def close(self):
         self.fd = None
+        # we do this so that the testing covers the error part of the branch
+        raise OSError('error closing the bus')
 
     def __common_read(self, dev_id, address):
         if random.random() < self.__err:
@@ -168,7 +171,7 @@ class MockSMBus(SMBus):
 
     def __common_write(self, dev_id, address, value):
         if random.random() < self.__err:
-            raise OSError('failed to read')
+            raise OSError('failed to write')
         else:
             return None
 

--- a/roboglia/i2c/device.py
+++ b/roboglia/i2c/device.py
@@ -1,0 +1,69 @@
+# Copyright (C) 2020  Alex Sonea
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+from pathlib import Path
+
+from ..base import BaseDevice
+
+logger = logging.getLogger(__name__)
+
+
+class I2CDevice(BaseDevice):
+
+    def __init__(self, init_dict):
+        super().__init__(init_dict)
+
+    def get_model_path(self):
+        """Builds the path to the `.yml` documents.
+
+        Returns:
+            str :A full document path including the name of the model and the
+                extension `.yml`.
+        """
+        # return os.path.join(os.path.dirname(__file__), 'devices')
+        return Path(__file__).parent / 'devices/'
+
+    # def register_low_endian(self, value, size):
+    #     """Converts a value into a list of bytes in little endian order.
+
+    #     Args:
+    #         value (int): the value of the register
+    #         size (int): the size of the register
+
+    #     Returns:
+    #         (list) List of bytes of len ``size`` with bytes ordered lowest
+    #             first.
+    #     """
+    #     if size == 1:
+    #         return [value]
+    #     elif size == 2:
+    #         return [DXL_LOBYTE(value), DXL_HIBYTE(value)]
+    #     elif size == 4:
+    #         lw = DXL_LOWORD(value)
+    #         hw = DXL_HIWORD(value)
+    #         return [DXL_LOBYTE(lw), DXL_HIBYTE(lw),
+    #                 DXL_LOBYTE(hw), DXL_HIBYTE(hw)]
+    #     else:
+    #         logger.error(f'Unexpected register size: {size}')
+    #         return None
+
+    def open(self):
+        """Reads all registers of the device if not synced.
+        """
+        for reg in self.registers.values():
+            # only registers that are not flagged for sync replication
+            if not reg.sync:
+                reg.int_value = self.read_register(reg)

--- a/roboglia/i2c/devices/DUMMY.yml
+++ b/roboglia/i2c/devices/DUMMY.yml
@@ -1,0 +1,70 @@
+# an example I2C device for testing purposes
+#
+registers:
+  control_1:
+    address: 1
+    access: RW
+    default: 42
+    desc: Control Accelerometer 
+
+  word_control_2:
+    address: 2
+    size: 2
+    access: RW
+    default: 0x4242
+    desc: A 2 Byte control register
+
+  byte_xl_x:
+    address: 4
+    access: RW
+    desc: Accelerometer X Byte Register
+
+  byte_xl_y:
+    address: 5
+    access: RW
+    desc: Accelerometer Y Byte Register
+
+  byte_xl_z:
+    address: 6
+    access: RW
+    desc: Accelerometer Z Byte Register
+
+  word_xl_x:
+    address: 7
+    size: 2
+    access: RW
+    desc: Accelerometer X Word Register
+
+  word_xl_y:
+    address: 9
+    size: 2
+    access: RW
+    desc: Accelerometer Y Word Register
+
+  word_xl_z:
+    address: 11
+    size: 2
+    access: RW
+    desc: Accelerometer Z Word Register
+
+  temp:
+    address: 12
+    access: R
+    desc: Temperature
+
+  word_g_x:
+    address: 13
+    size: 2
+    desc: Gyro X Word Register
+
+  word_g_y:
+    address: 15
+    size: 2
+    desc: Gyro Y Word Register
+
+  word_g_z:
+    address: 17
+    size: 2
+    desc: Gyro Z Word Register
+
+  

--- a/roboglia/i2c/devices/LSM6DS3.yml
+++ b/roboglia/i2c/devices/LSM6DS3.yml
@@ -130,13 +130,10 @@ registers:
     address: 30
     desc: Status data register 
 
-  out_temp_l:
+  out_temp:
     address: 32
+    size: 2
     desc: Temperature output data register 
-
-  out_temp_h:
-    address: 33
-    desc: Temperature output data register
 
   outx_l_g:
     address: 34

--- a/roboglia/i2c/devices/LSM6DS3.yml
+++ b/roboglia/i2c/devices/LSM6DS3.yml
@@ -1,0 +1,379 @@
+# iNEMO inertial module: always-on 3D accelerometer and 3D gyroscope
+# https://www.st.com/resource/en/datasheet/lsm6ds3.pdf
+#
+registers:
+  func_cfg_access:
+    address: 1
+    access: RW
+    desc: Embedded functions configuration register 
+
+  sensor_sync_time_frame:
+    address: 4
+    access: RW
+    desc: Sensor sync configuration register
+
+  fifo_ctrl1:
+    address: 6
+    access: RW
+    desc: FIFO configuration registers 
+
+  fifo_ctrl2:
+    address: 7
+    access: RW
+    desc: FIFO configuration registers 
+
+  fifo_ctrl3:
+    address: 8
+    access: RW
+    desc: FIFO configuration registers 
+
+  fifo_ctrl4:
+    address: 9
+    access: RW
+    desc: FIFO configuration registers 
+
+  fifo_ctrl5:
+    address: 10
+    access: RW
+    desc: FIFO configuration registers 
+
+  orient_cfg_g:
+    address: 11
+    access: RW
+
+  int1_ctrl:
+    address: 13
+    access: RW
+    desc: INT1 pin control 
+
+  int1_ctr2:
+    address: 14
+    access: RW
+    desc: INT2 pin control 
+
+  who_am_i:
+    address: 15
+    default: 105
+    desc: Who I am ID 
+
+  ctrl1_xl:
+    address: 16
+    access: RW
+    desc: Accelerometer and gyroscope control registers 
+
+  ctrl2_g:
+    address: 17
+    access: RW
+    desc: Accelerometer and gyroscope control registers 
+
+  ctrl3_c:
+    address: 18
+    access: RW
+    default: 4
+    desc: Accelerometer and gyroscope control registers 
+
+  ctrl4_c:
+    address: 19
+    access: RW
+    desc: Accelerometer and gyroscope control registers 
+
+  ctrl5_c:
+    address: 20
+    access: RW
+    desc: Accelerometer and gyroscope control registers 
+
+  ctrl6_c:
+    address: 21
+    access: RW
+    desc: Accelerometer and gyroscope control registers 
+
+  ctrl7_g:
+    address: 22
+    access: RW
+    desc: Accelerometer and gyroscope control registers 
+
+  ctrl8_xl:
+    address: 23
+    access: RW
+    desc: Accelerometer and gyroscope control registers 
+
+  ctrl9_xl:
+    address: 24
+    access: RW
+    default: 56
+    desc: Accelerometer and gyroscope control registers 
+
+  ctrl10_c:
+    address: 25
+    access: RW
+    default: 56
+    desc: Accelerometer and gyroscope control registers
+
+  master_config:
+    address: 26
+    access: RW
+    desc: I2C master configuration register 
+
+  wake_up_src:
+    address: 27
+    desc: Interrupts registers 
+
+  tap_src:
+    address: 28
+    desc: Interrupts registers 
+
+  d6d_src:
+    address: 29
+    desc: Interrupts registers 
+
+  status_reg:
+    address: 30
+    desc: Status data register 
+
+  out_temp_l:
+    address: 32
+    desc: Temperature output data register 
+
+  out_temp_h:
+    address: 33
+    desc: Temperature output data register
+
+  outx_l_g:
+    address: 34
+    desc: Gyroscope output register 
+
+  outx_h_g:
+    address: 35
+    desc: Gyroscope output register 
+
+  outy_l_g:
+    address: 36
+    desc: Gyroscope output register 
+
+  outy_h_g:
+    address: 37
+    desc: Gyroscope output register 
+
+  outz_l_g:
+    address: 38
+    desc: Gyroscope output register 
+
+  outz_h_g:
+    address: 39
+    desc: Gyroscope output register 
+
+  outx_l_xl:
+    address: 40
+    desc: Accelerometer output register  
+
+  outx_h_xl:
+    address: 41
+    desc: Accelerometer output register
+
+  outy_l_xl:
+    address: 42
+    desc: Accelerometer output register
+
+  outy_h_xl:
+    address: 43
+    desc: Accelerometer output register
+
+  outz_l_xl:
+    address: 44
+    desc: Accelerometer output register
+
+  outz_h_xl:
+    address: 45
+    desc: Accelerometer output register
+
+  sensorhub1_reg:
+    address: 46
+    desc: Sensor hub output registers 
+
+  sensorhub2_reg:
+    address: 47
+    desc: Sensor hub output registers 
+
+  sensorhub3_reg:
+    address: 48
+    desc: Sensor hub output registers 
+
+  sensorhub4_reg:
+    address: 49
+    desc: Sensor hub output registers
+
+  sensorhub5_reg:
+    address: 50
+    desc: Sensor hub output registers 
+
+  sensorhub6_reg:
+    address: 51
+    desc: Sensor hub output registers 
+
+  sensorhub7_reg:
+    address: 52
+    desc: Sensor hub output registers 
+
+  sensorhub8_reg:
+    address: 53
+    desc: Sensor hub output registers
+
+  sensorhub9_reg:
+    address: 54
+    desc: Sensor hub output registers
+
+  sensorhub10_reg:
+    address: 55
+    desc: Sensor hub output registers 
+
+  sensorhub11_reg:
+    address: 56
+    desc: Sensor hub output registers 
+
+  sensorhub12_reg:
+    address: 57
+    desc: Sensor hub output registers 
+
+  fifo_status1:
+    address: 58
+    desc: FIFO status registers 
+
+  fifo_status2:
+    address: 59
+    desc: FIFO status registers
+
+  fifo_status3:
+    address: 60 
+    desc: FIFO status registers 
+
+  fifo_status4:
+    address: 61
+    desc: FIFO status registers 
+
+  fifo_data_out_l:
+    address: 62
+    desc: FIFO data output registers 
+
+  fifo_data_out_h:
+    address: 63
+    desc: FIFO data output registers 
+
+  timestamp0_reg:
+    address: 64
+    desc: Timestamp output registers 
+
+  timestamp1_reg:
+    address: 65
+    desc: Timestamp output registers
+
+  timestamp2_reg:
+    address: 66
+    desc: Timestamp output registers
+
+  step_timestamp_l:
+    address: 73
+    desc: Step counter timestamp registers
+
+  step_timestamp_h:
+    address: 74
+    desc: Step counter timestamp registers
+
+  step_counter_l:
+    address: 75
+    desc: Step counter output registers
+
+  step_counter_h:
+    address: 76
+    desc: Step counter output registers
+
+  sensorhub13_reg:
+    address: 77
+    desc: Sensor hub output registers
+
+  sensorhub14_reg:
+    address: 78
+    desc: Sensor hub output registers
+
+  sensorhub15_reg:
+    address: 79
+    desc: Sensor hub output registers
+
+  sensorhub16_reg:
+    address: 80
+    desc: Sensor hub output registers
+
+  sensorhub17_reg:
+    address: 81
+    desc: Sensor hub output registers
+
+  sensorhub18_reg:
+    address: 82
+    desc: Sensor hub output registers
+
+  func_src:
+    address: 83
+    desc: Interrupt register
+
+  tap_cfg:
+    address: 88
+    access: RW
+    desc: Interrupt registers
+
+  tap_ths_6d :
+    address: 89
+    access: RW
+    desc: Interrupt registers
+
+  int_dur2 :
+    address: 90
+    access: RW
+    desc: Interrupt registers
+
+  wake_up_ths:
+    address: 91
+    access: RW
+    desc: Interrupt registers
+
+  wake_up_dur:
+    address: 92
+    access: RW
+    desc: Interrupt registers
+
+  free_fall:
+    address: 93
+    access: RW
+    desc: Interrupt registers
+
+  md1_cfg:
+    address: 94
+    access: RW
+    desc: Interrupt registers
+
+  md2_cfg:
+    address: 95
+    access: RW
+    desc: Interrupt registers
+
+  out_mag_raw_x_l:
+    address: 102
+    desc: External magnetometer raw data output registers 
+
+  out_mag_raw_x_h:
+    address: 103
+    desc: External magnetometer raw data output registers 
+
+  out_mag_raw_y_l:
+    address: 104
+    desc: External magnetometer raw data output registers 
+
+  out_mag_raw_y_h:
+    address: 105
+    desc: External magnetometer raw data output registers 
+
+  out_mag_raw_z_l:
+    address: 106
+    desc: External magnetometer raw data output registers 
+
+  out_mag_raw_z_h:
+    address: 107
+    desc: External magnetometer raw data output registers 

--- a/roboglia/i2c/sync.py
+++ b/roboglia/i2c/sync.py
@@ -1,0 +1,109 @@
+# Copyright (C) 2020  Alex Sonea
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+
+from ..base import BaseSync
+
+logger = logging.getLogger(__name__)
+
+
+class I2CWriteLoop(BaseSync):
+    """Implements a write loop that is leveraging the ability to write a
+    range of registers in one go.
+
+    The devices are provided in the `group` parameter and the registers
+    in the `registers` as a list of register names.
+    It will update from `int_value` of each register for every device.
+    Will log errors and not raise any exceptions.
+    """
+    def setup(self):
+        """ Determines the start address and lengths for each bulk write.
+        Previously the constructor checked that all registers are
+        available in all devices.
+        """
+        self.start_address, self.length = self.get_register_range()
+
+    def atomic(self):
+        """Executes a SyncWrite."""
+        for device in self.devices:
+            # prepare data
+            data = [0] * self.length
+            for reg_name in self.registers:
+                register = getattr(device, reg_name)
+                pos = register.address - self.start_address
+                if register.size == 1:
+                    data[pos] = register.int_value
+                elif register.size == 2:
+                    data[pos] = register.int_value % 256
+                    data[pos + 1] = register.int_value // 256
+                else:
+                    raise NotImplementedError
+
+            # write
+            try:
+                self.bus.write_block_data(device,
+                                          self.start_address,
+                                          self.length,
+                                          data)
+            except Exception as e:
+                logger.error('failed to execute block data write on'
+                             f'I2C bus for I2CWriteLoop {self.name} '
+                             f'and device {device.name}')
+                logger.error(str(e))
+            logger.debug(f'{self.name} written block data {data}')
+
+
+class I2CReadLoop(BaseSync):
+    """Implements a read loop that is leveraging the ability to read a
+    range of registers in one go.
+
+    The devices are provided in the `group` parameter and the registers
+    in the `registers` as a list of register names.
+    It will update the `int_value` of each register for every device.
+    Will log errors and not raise any exceptions.
+    """
+    def setup(self):
+        """ Determines the start address and lengths for each bulk write.
+        Previously the constructor checked that all registers are
+        available in all devices.
+        """
+        self.start_address, self.length = self.get_register_range()
+
+    def atomic(self):
+        """Executes a SyncRead."""
+        for device in self.devices:
+            # read one device
+            try:
+                data = self.bus.read_block_data(device,
+                                                self.start_address,
+                                                self.length)
+            except Exception as e:
+                logger.error(f'{self.name} failed to execute block data read '
+                             f'for device {device.name}')
+                logger.error(str(e))
+                continue
+
+            logger.debug(f'{self.name} read block data {data}')
+            if data is not None:
+                for reg_name in self.registers:
+                    register = getattr(device, reg_name)
+                    pos = register.address - self.start_address
+                    if register.size == 1:
+                        register.int_value = data[pos]
+                    elif register.size == 2:
+                        register.int_value = data[pos] + data[pos + 1] * 256
+                    else:
+                        raise NotImplementedError

--- a/tests.py
+++ b/tests.py
@@ -16,10 +16,10 @@ from roboglia.dynamixel import DynamixelXLBaudRateRegister
 
 from roboglia.i2c import SharedI2CBus
 
-format = '%(asctime)s %(levelname)-7s %(threadName)-18s %(name)-32s %(message)s'
-logging.basicConfig(format=format, 
-                    # file = 'test.log', 
-                    level=60)    # silent
+# format = '%(asctime)s %(levelname)-7s %(threadName)-18s %(name)-32s %(message)s'
+# logging.basicConfig(format=format, 
+#                     # file = 'test.log', 
+#                     level=60)    # silent
 logger = logging.getLogger(__name__)
 
 

--- a/tests/dummy_robot.yml
+++ b/tests/dummy_robot.yml
@@ -1,13 +1,13 @@
-# robot defintion file for running automated tests
+# robot definition file for running automated tests
 #
 dummy:
   buses:
     busA:
-      class: ShareableFileBus
+      class: SharedFileBus
       port: /tmp/busA.log
 
     busB:
-      class: ShareableFileBus
+      class: SharedFileBus
       port: /tmp/busB.log
       auto: False
 

--- a/tests/dynamixel_robot.yml
+++ b/tests/dynamixel_robot.yml
@@ -1,13 +1,14 @@
-# robot defintion file for running automated tests
+# robot definition file for running automated tests
 #
 dynamixel:
   buses:
     ttys1:
-      class: MockDynamixelBus
+      class: SharedDynamixelBus
       port: /dev/ttys1
       baudrate: 19200
       protocol: 2.0
       auto: True
+      mock: True
 
   devices:
     d11:

--- a/tests/i2c_robot.yml
+++ b/tests/i2c_robot.yml
@@ -1,0 +1,17 @@
+# robot definition file for running automated tests
+#
+i2crobot:
+  buses:
+    i2c2:
+      class: SharedI2CBus
+      port: 2
+      auto: True
+      mock: True
+
+  devices:
+    imu:
+      class: I2CDevice
+      bus: i2c2
+      id: 11
+      model: LSM6DS3
+      auto: True

--- a/tests/i2c_robot.yml
+++ b/tests/i2c_robot.yml
@@ -15,3 +15,22 @@ i2crobot:
       id: 11
       model: DUMMY
       auto: True
+
+  groups:
+    imu:
+      devices: [imu]
+
+  syncs:
+    read_g:
+      class: I2CReadLoop
+      group: imu
+      registers: [word_g_x, word_g_y, word_g_z]
+      frequency: 50.0
+      auto: False
+
+    write_xl:
+      class: I2CWriteLoop
+      group: imu
+      registers: [word_xl_x, word_xl_y, word_xl_z]
+      frequency: 50.0
+      auto: False

--- a/tests/i2c_robot.yml
+++ b/tests/i2c_robot.yml
@@ -13,5 +13,5 @@ i2crobot:
       class: I2CDevice
       bus: i2c2
       id: 11
-      model: LSM6DS3
+      model: DUMMY
       auto: True


### PR DESCRIPTION
Includes:
- i2s bus, with Mockbus
- i2c device
- i2c sync

Tests updated to cover the additional function.

Also the SharedBus is now simplified and no longer using multiple inheritance. It is possible to switch from the robot definition to a mock bus by using 'mock: True' for DynamixeBus and I2CBus (or the Shared equivalents).