### PR TITLE
Partial bit masks

### DIFF
--- a/roboglia/base/devices/DUMMY.yml
+++ b/roboglia/base/devices/DUMMY.yml
@@ -109,13 +109,11 @@ registers:
     access: RW
     class: BoolRegister
 
-
   status_one:
     address: 99
     clone: True
     class: BoolRegister
     bits: 0b00000001
-
 
   status_2and3:
     address: 99
@@ -131,3 +129,12 @@ registers:
     class: BoolRegister
     bits: 0b00000110
     mode: any
+
+  status_masked:
+    address: 99
+    clone: True
+    access: RW
+    class: BoolRegister
+    bits: 0b10100000
+    mask: 0b11110000
+    mode: all  

--- a/roboglia/base/devices/DUMMY.yml
+++ b/roboglia/base/devices/DUMMY.yml
@@ -114,7 +114,7 @@ registers:
     address: 99
     clone: True
     class: BoolRegister
-    mask: 0b00000001
+    bits: 0b00000001
 
 
   status_2and3:
@@ -122,12 +122,12 @@ registers:
     clone: True
     access: RW
     class: BoolRegister
-    mask: 0b00000110
+    bits: 0b00000110
     mode: all
 
   status_2or3:
     address: 99
     clone: True
     class: BoolRegister
-    mask: 0b00000110
+    bits: 0b00000110
     mode: any

--- a/roboglia/base/devices/DUMMY.yml
+++ b/roboglia/base/devices/DUMMY.yml
@@ -137,4 +137,4 @@ registers:
     class: BoolRegister
     bits: 0b10100000
     mask: 0b11110000
-    mode: all  
+    mode: all

--- a/roboglia/base/register.py
+++ b/roboglia/base/register.py
@@ -457,10 +457,10 @@ class BoolRegister(BaseRegister):
             if self.bits:
                 return self.bits
             return 1
-        else:
+        # else:   not really needed
             # the int() below is to remove a linter error
-            masked_int_value = self.int_value & (~ int(self.mask))
-            return self.bits | masked_int_value
+        masked_int_value = self.int_value & (~ int(self.mask))
+        return self.bits | masked_int_value
 
 
 class RegisterWithConversion(BaseRegister):

--- a/roboglia/base/register.py
+++ b/roboglia/base/register.py
@@ -389,29 +389,29 @@ class BoolRegister(BaseRegister):
 
     Parameters
     ----------
-    mask: int or ``None``
-        An optional mask to use in the determination of the output of the
-        register. Default is None and in this case we simply compare the
+    bits: int or ``None``
+        An optional bit pattern to use in the determination of the output of
+        the register. Default is None and in this case we simply compare the
         internal value with 0.
 
     mode: str ('all' or 'any')
-        Indicates how the mask should be used: 'all' means all the bits
-        in the mask must match  while 'any'
-        means any bit that matches the mask is enough to result in a ``True``
-        external value. Only used if mask is not ``None``. Default is 'any'.
+        Indicates how the bit pattern should be used: 'all' means all the bits
+        in the pattern must match  while 'any'
+        means any bit that matches the pattern is enough to result in a ``True``
+        external value. Only used if bits is not ``None``. Default is 'any'.
     """
-    def __init__(self, mask=None, mode='any', **kwargs):
+    def __init__(self, bits=None, mode='any', **kwargs):
         super().__init__(**kwargs)
-        if mask:
-            check_type(mask, int, 'register', self.name, logger)
+        if bits:
+            check_type(bits, int, 'register', self.name, logger)
             check_options(mode, ['all', 'any'], 'register', self.name, logger)
-        self.__mask = mask
+        self.bit = bits
         self.__mode = mode
 
     @property
-    def mask(self):
-        """The mask used."""
-        return self.__mask
+    def bits(self):
+        """The bit pattern used."""
+        return self.__bits
 
     @property
     def mode(self):
@@ -421,12 +421,12 @@ class BoolRegister(BaseRegister):
     def value_to_external(self, value):
         """The external representation of bool register.
         """
-        if self.mask is None:
+        if self.bits is None:
             return bool(value)
         if self.mode == 'any':
-            return bool(value & self.mask)
+            return bool(value & self.bits)
         if self.mode == 'all':
-            return (value & self.mask) == self.mask
+            return (value & self.bits) == self.bits
         raise NotImplementedError
 
     def value_to_internal(self, value):
@@ -434,8 +434,8 @@ class BoolRegister(BaseRegister):
         """
         if not value:
             return 0
-        if self.mask:
-            return self.mask
+        if self.bits:
+            return self.bits
         return 1
 
 

--- a/roboglia/base/register.py
+++ b/roboglia/base/register.py
@@ -397,15 +397,16 @@ class BoolRegister(BaseRegister):
     mode: str ('all' or 'any')
         Indicates how the bit pattern should be used: 'all' means all the bits
         in the pattern must match  while 'any'
-        means any bit that matches the pattern is enough to result in a ``True``
-        external value. Only used if bits is not ``None``. Default is 'any'.
+        means any bit that matches the pattern is enough to result in a
+        ``True`` external value. Only used if bits is not ``None``. Default
+        is 'any'.
     """
     def __init__(self, bits=None, mode='any', **kwargs):
         super().__init__(**kwargs)
         if bits:
             check_type(bits, int, 'register', self.name, logger)
             check_options(mode, ['all', 'any'], 'register', self.name, logger)
-        self.bit = bits
+        self.__bits = bits
         self.__mode = mode
 
     @property

--- a/roboglia/base/sensor.py
+++ b/roboglia/base/sensor.py
@@ -157,7 +157,6 @@ class Sensor():
         """(read-only) The offset between sensor coords and device coords."""
         return self.__offset
 
-
     @property
     def value(self):
         """Returns the value of the sensor.

--- a/roboglia/dynamixel/devices/AX-12A.yml
+++ b/roboglia/dynamixel/devices/AX-12A.yml
@@ -140,49 +140,49 @@ registers:
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b01000000
+    bits: 0b01000000
 
   alarm_overload_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00100000
+    bits: 0b00100000
 
   alarm_checksum_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00010000
+    bits: 0b00010000
 
   alarm_range_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00001000
+    bits: 0b00001000
 
   alarm_overheating_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00000100
+    bits: 0b00000100
 
   alarm_anglelimit_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00000010
+    bits: 0b00000010
 
   alarm_inputvoltage_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00000001
+    bits: 0b00000001
 
   shutdown:
     address: 18
@@ -194,49 +194,49 @@ registers:
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b01000000
+    bits: 0b01000000
 
   shutdown_overload_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00100000
+    bits: 0b00100000
 
   shutdown_checksum_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00010000
+    bits: 0b00010000
 
   shutdown_range_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00001000
+    bits: 0b00001000
 
   shutdown_overheating_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00000100
+    bits: 0b00000100
 
   shutdown_anglelimit_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00000010
+    bits: 0b00000010
 
   shutdown_inputvoltage_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00000001
+    bits: 0b00000001
 
   torque_enable:
     class: BoolRegister

--- a/roboglia/dynamixel/devices/AX-18A.yml
+++ b/roboglia/dynamixel/devices/AX-18A.yml
@@ -140,49 +140,49 @@ registers:
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b01000000
+    bits: 0b01000000
 
   alarm_overload_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00100000
+    bits: 0b00100000
 
   alarm_checksum_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00010000
+    bits: 0b00010000
 
   alarm_range_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00001000
+    bits: 0b00001000
 
   alarm_overheating_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00000100
+    bits: 0b00000100
 
   alarm_anglelimit_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00000010
+    bits: 0b00000010
 
   alarm_inputvoltage_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00000001
+    bits: 0b00000001
 
   shutdown:
     address: 18
@@ -194,49 +194,49 @@ registers:
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b01000000
+    bits: 0b01000000
 
   shutdown_overload_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00100000
+    bits: 0b00100000
 
   shutdown_checksum_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00010000
+    bits: 0b00010000
 
   shutdown_range_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00001000
+    bits: 0b00001000
 
   shutdown_overheating_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00000100
+    bits: 0b00000100
 
   shutdown_anglelimit_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00000010
+    bits: 0b00000010
 
   shutdown_inputvoltage_error:
     address: 17
     clone: True
     class: BoolRegister
     access: RW
-    mask: 0b00000001
+    bits: 0b00000001
 
   torque_enable:
     class: BoolRegister

--- a/roboglia/dynamixel/sync.py
+++ b/roboglia/dynamixel/sync.py
@@ -66,8 +66,7 @@ class DynamixelSyncWriteLoop(BaseSync):
             result = self.gsw.txPacket()
             self.bus.stop_using()       # !! as soon as possible
             error = self.gsw.ph.getTxRxResult(result)
-            logger.debug(f'[sync write {self.name}] for register '
-                         f'{reg_name}, result: {error}')
+            logger.debug(f'[sync write {self.name}], result: {error}')
             if result != 0:
                 logger.error(f'failed to execute SyncWrite {self.name}: '
                              f'cerr={error}')

--- a/roboglia/i2c/devices/DUMMY.yml
+++ b/roboglia/i2c/devices/DUMMY.yml
@@ -108,4 +108,3 @@ registers:
     access: RW
     clone: True
     bits: 0b00000010
-    

--- a/roboglia/i2c/devices/DUMMY.yml
+++ b/roboglia/i2c/devices/DUMMY.yml
@@ -94,3 +94,18 @@ registers:
     address: 23
     access: RW
     default: 0b01010101
+
+  status01:
+    address: 23
+    class: BoolRegister
+    access: RW
+    clone: True
+    bits: 0b00000001
+
+  status10:
+    address: 23
+    class: BoolRegister
+    access: RW
+    clone: True
+    bits: 0b00000010
+    

--- a/tests.py
+++ b/tests.py
@@ -276,7 +276,7 @@ class TestMockRobot:
         assert s.read_register == d.current_voltage
         assert s.activate_register is None
         assert s.active
-        assert s.mask is None
+        # assert s.bits is None
         assert s.offset == 0
         assert not s.inverse
         assert s.auto_activate
@@ -865,7 +865,8 @@ class TestI2CRobot:
         assert s.read_register == d.temp
         assert s.activate_register == d.activate_temp
         assert not s.active
-        assert s.mask is None
+        # removed the masking in sensor
+        # assert s.bits is None
         assert s.offset == 0
         assert s.inverse
         assert s.auto_activate

--- a/tests.py
+++ b/tests.py
@@ -88,6 +88,13 @@ class TestMockRobot:
         assert device.status_2and3.value
         assert device.status_2and3.int_value == 0b00000110
 
+    def test_register_bool_with_mask(self, mock_robot):
+        device = mock_robot.devices['d03']
+        assert not device.status_masked.value
+        device.status_masked.value = True
+        assert device.status_masked.value
+        assert device.status_masked.int_value == 0b10100101
+
     def test_register_with_conversion(self, mock_robot, caplog):
         reg = mock_robot.devices['d03'].desired_pos
         assert isinstance(reg, RegisterWithConversion)

--- a/tests/i2c_robot.yml
+++ b/tests/i2c_robot.yml
@@ -58,13 +58,13 @@ i2crobot:
       class: Sensor
       device: imu
       value_read: status
-      mask: 0b00000001
+      bits: 0b00000001
 
     status1:
       class:  Sensor
       device: imu
       value_read: status
-      mask: 0b00000010
+      bits: 0b00000010
 
   groups:
     imu:

--- a/tests/i2c_robot.yml
+++ b/tests/i2c_robot.yml
@@ -57,14 +57,12 @@ i2crobot:
     status0:
       class: Sensor
       device: imu
-      value_read: status
-      bits: 0b00000001
+      value_read: status01
 
     status1:
       class:  Sensor
       device: imu
-      value_read: status
-      bits: 0b00000010
+      value_read: status10
 
   groups:
     imu:


### PR DESCRIPTION
Change the terminology: now "bits" used to compare the internal value in register and "mask" used for partial control of the bitwise values.

Fixes #74 
Fixes #72 